### PR TITLE
MP-200 :recycle: Refactor: 도메인 필드 네이밍 컨벤션 통일

### DIFF
--- a/src/main/java/kr/modusplant/domains/communication/common/error/EntityExistsWithPostUlidAndMatePathException.java
+++ b/src/main/java/kr/modusplant/domains/communication/common/error/EntityExistsWithPostUlidAndMatePathException.java
@@ -7,5 +7,5 @@ public class EntityExistsWithPostUlidAndMatePathException extends EntityExistsEx
         super(message);
     }
 
-    public EntityExistsWithPostUlidAndMatePathException() {super("Entity exists with postUlid and matePath"); }
+    public EntityExistsWithPostUlidAndMatePathException() {super("Entity exists with postUlid and path"); }
 }

--- a/src/main/java/kr/modusplant/domains/communication/common/error/EntityNotFoundWithPostUlidAndMatePathException.java
+++ b/src/main/java/kr/modusplant/domains/communication/common/error/EntityNotFoundWithPostUlidAndMatePathException.java
@@ -4,5 +4,5 @@ public class EntityNotFoundWithPostUlidAndMatePathException extends RuntimeExcep
     public EntityNotFoundWithPostUlidAndMatePathException(String message) {
         super(message);
     }
-    public EntityNotFoundWithPostUlidAndMatePathException() { super("Entity not found with postUlid and matePath"); }
+    public EntityNotFoundWithPostUlidAndMatePathException() { super("Entity not found with postUlid and path"); }
 }

--- a/src/main/java/kr/modusplant/domains/communication/conversation/app/service/ConvLikeApplicationService.java
+++ b/src/main/java/kr/modusplant/domains/communication/conversation/app/service/ConvLikeApplicationService.java
@@ -20,26 +20,26 @@ public class ConvLikeApplicationService {
     private final ConvLikeValidationService convLikeValidationService;
 
     @Transactional
-    public LikeResponse likeConvPost(String convPostId, UUID memberId) {
-        convLikeValidationService.validateExistedConvPostAndMember(convPostId, memberId);
-        convLikeValidationService.validateConvLikeNotExists(convPostId, memberId);
+    public LikeResponse likeConvPost(String postId, UUID memberId) {
+        convLikeValidationService.validateExistedConvPostAndMember(postId, memberId);
+        convLikeValidationService.validateConvLikeNotExists(postId, memberId);
 
-        ConvPostEntity convPost = convPostRepository.findById(convPostId).orElseThrow(() -> new IllegalArgumentException("conv post not found"));
+        ConvPostEntity convPost = convPostRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("conv post not found"));
         convPost.increaseLikeCount();
 
-        convLikeRepository.save(ConvLikeEntity.of(convPostId, memberId));
+        convLikeRepository.save(ConvLikeEntity.of(postId, memberId));
         return LikeResponse.of(convPost.getLikeCount(), true);
     }
 
     @Transactional
-    public LikeResponse unlikeConvPost(String convPostId, UUID memberId) {
-        convLikeValidationService.validateExistedConvPostAndMember(convPostId, memberId);
-        convLikeValidationService.validateConvLikeExists(convPostId, memberId);
+    public LikeResponse unlikeConvPost(String postId, UUID memberId) {
+        convLikeValidationService.validateExistedConvPostAndMember(postId, memberId);
+        convLikeValidationService.validateConvLikeExists(postId, memberId);
 
-        ConvPostEntity convPost = convPostRepository.findById(convPostId).orElseThrow(() -> new IllegalArgumentException("conv post not found"));
+        ConvPostEntity convPost = convPostRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("conv post not found"));
         convPost.decreaseLikeCount();
 
-        convLikeRepository.deleteByConvPostIdAndMemberId(convPostId, memberId);
+        convLikeRepository.deleteByPostIdAndMemberId(postId, memberId);
         return LikeResponse.of(convPost.getLikeCount(), false);
     }
 }

--- a/src/main/java/kr/modusplant/domains/communication/conversation/domain/model/ConvLike.java
+++ b/src/main/java/kr/modusplant/domains/communication/conversation/domain/model/ConvLike.java
@@ -10,6 +10,6 @@ import java.util.UUID;
 @Builder(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ConvLike {
-    private String convPostId;
+    private String postId;
     private UUID memberId;
 }

--- a/src/main/java/kr/modusplant/domains/communication/conversation/domain/service/ConvLikeValidationService.java
+++ b/src/main/java/kr/modusplant/domains/communication/conversation/domain/service/ConvLikeValidationService.java
@@ -21,27 +21,27 @@ public class ConvLikeValidationService {
     private final SiteMemberRepository memberRepository;
     private final ConvLikeRepository convLikeRepository;
 
-    public void validateExistedConvPostAndMember(String convPostId, UUID memberId) {
-        if (convPostId == null || memberId == null) {
-            throw new IllegalArgumentException("convPostId and memberId must not be null");
-        };
+    public void validateExistedConvPostAndMember(String postId, UUID memberId) {
+        if (postId == null || memberId == null) {
+            throw new IllegalArgumentException("postId and memberId must not be null");
+        }
 
-        if (!convPostRepository.existsById(convPostId)) {
-            throw new EntityNotFoundWithUlidException(convPostId, ConvPostEntity.class);
+        if (!convPostRepository.existsById(postId)) {
+            throw new EntityNotFoundWithUlidException(postId, ConvPostEntity.class);
         }
         if (!memberRepository.existsById(memberId)) {
             throw new EntityExistsWithUuidException(memberId, SiteMemberEntity.class);
         }
     }
 
-    public void validateConvLikeExists(String convPostId, UUID memberId) {
-        if (!convLikeRepository.existsByConvPostIdAndMemberId(convPostId, memberId)) {
+    public void validateConvLikeExists(String postId, UUID memberId) {
+        if (!convLikeRepository.existsByPostIdAndMemberId(postId, memberId)) {
             throw new IllegalArgumentException("member not liked status");
         }
     }
 
-    public void validateConvLikeNotExists(String convPostId, UUID memberId) {
-        if (convLikeRepository.existsByConvPostIdAndMemberId(convPostId, memberId)) {
+    public void validateConvLikeNotExists(String postId, UUID memberId) {
+        if (convLikeRepository.existsByPostIdAndMemberId(postId, memberId)) {
             throw new IllegalArgumentException("member already liked");
         }
     }

--- a/src/main/java/kr/modusplant/domains/communication/conversation/persistence/entity/ConvCommentEntity.java
+++ b/src/main/java/kr/modusplant/domains/communication/conversation/persistence/entity/ConvCommentEntity.java
@@ -33,7 +33,7 @@ public class ConvCommentEntity {
     private ConvPostEntity postEntity;
 
     @Id
-    @Column(name = "mate_path", nullable = false, updatable = false)
+    @Column(name = "path", nullable = false, updatable = false)
     private String path;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE}, optional = false)

--- a/src/main/java/kr/modusplant/domains/communication/conversation/persistence/entity/ConvLikeEntity.java
+++ b/src/main/java/kr/modusplant/domains/communication/conversation/persistence/entity/ConvLikeEntity.java
@@ -21,7 +21,7 @@ import static kr.modusplant.global.vo.SnakeCaseWord.*;
 public class ConvLikeEntity {
     @Id
     @Column(name = SNAKE_POST_ULID, nullable = false)
-    private String convPostId;
+    private String postId;
 
     @Id
     @Column(name = SNAKE_MEMB_UUID, nullable = false)
@@ -31,12 +31,12 @@ public class ConvLikeEntity {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    private ConvLikeEntity(String convPostId, UUID memberId) {
-        this.convPostId = convPostId;
+    private ConvLikeEntity(String postId, UUID memberId) {
+        this.postId = postId;
         this.memberId = memberId;
     }
 
-    public static ConvLikeEntity of(String convPostId, UUID memberId) {
-        return new ConvLikeEntity(convPostId, memberId);
+    public static ConvLikeEntity of(String postId, UUID memberId) {
+        return new ConvLikeEntity(postId, memberId);
     }
 }

--- a/src/main/java/kr/modusplant/domains/communication/conversation/persistence/entity/ConvLikeId.java
+++ b/src/main/java/kr/modusplant/domains/communication/conversation/persistence/entity/ConvLikeId.java
@@ -12,6 +12,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class ConvLikeId implements Serializable {
-    private String convPostId;
+    private String postId;
     private UUID memberId;
 }

--- a/src/main/java/kr/modusplant/domains/communication/conversation/persistence/repository/ConvLikeRepository.java
+++ b/src/main/java/kr/modusplant/domains/communication/conversation/persistence/repository/ConvLikeRepository.java
@@ -14,8 +14,8 @@ public interface ConvLikeRepository extends JpaRepository<ConvLikeEntity, ConvLi
     List<ConvLikeEntity> findByMemberId(UUID memberId);
 
     // 사용자별 대화 게시글 좋아요 리스트 조회
-    List<ConvLikeEntity> findByMemberIdAndConvPostIdIn(UUID memberId, List<String> convPostIds);
+    List<ConvLikeEntity> findByMemberIdAndPostIdIn(UUID memberId, List<String> postIds);
 
-    boolean existsByConvPostIdAndMemberId(String convPostId, UUID memberId);
-    void deleteByConvPostIdAndMemberId(String convPostId, UUID memberId);
+    boolean existsByPostIdAndMemberId(String postId, UUID memberId);
+    void deleteByPostIdAndMemberId(String postId, UUID memberId);
 }

--- a/src/main/java/kr/modusplant/domains/communication/qna/app/service/QnaLikeApplicationService.java
+++ b/src/main/java/kr/modusplant/domains/communication/qna/app/service/QnaLikeApplicationService.java
@@ -20,26 +20,26 @@ public class QnaLikeApplicationService {
     private final QnaLikeValidationService qnaLikeValidationService;
 
     @Transactional
-    public LikeResponse likeQnaPost(String qnaPostId, UUID memberId) {
-        qnaLikeValidationService.validateExistedQnaPostAndMember(qnaPostId, memberId);
-        qnaLikeValidationService.validateQnaLikeNotExists(qnaPostId, memberId);
+    public LikeResponse likeQnaPost(String postId, UUID memberId) {
+        qnaLikeValidationService.validateExistedQnaPostAndMember(postId, memberId);
+        qnaLikeValidationService.validateQnaLikeNotExists(postId, memberId);
 
-        QnaPostEntity qnaPost = qnaPostRepository.findById(qnaPostId).orElseThrow(() -> new IllegalArgumentException("qna post not found"));
+        QnaPostEntity qnaPost = qnaPostRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("qna post not found"));
         qnaPost.increaseLikeCount();
 
-        qnaLikeRepository.save(QnaLikeEntity.of(qnaPostId, memberId));
+        qnaLikeRepository.save(QnaLikeEntity.of(postId, memberId));
         return LikeResponse.of(qnaPost.getLikeCount(), true);
     }
 
     @Transactional
-    public LikeResponse unlikeQnaPost(String qnaPostId, UUID memberId) {
-        qnaLikeValidationService.validateExistedQnaPostAndMember(qnaPostId, memberId);
-        qnaLikeValidationService.validateQnaLikeExists(qnaPostId, memberId);
+    public LikeResponse unlikeQnaPost(String postId, UUID memberId) {
+        qnaLikeValidationService.validateExistedQnaPostAndMember(postId, memberId);
+        qnaLikeValidationService.validateQnaLikeExists(postId, memberId);
 
-        QnaPostEntity qnaPost = qnaPostRepository.findById(qnaPostId).orElseThrow(() -> new IllegalArgumentException("qna post not found"));
+        QnaPostEntity qnaPost = qnaPostRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("qna post not found"));
         qnaPost.decreaseLikeCount();
 
-        qnaLikeRepository.deleteByQnaPostIdAndMemberId(qnaPostId, memberId);
+        qnaLikeRepository.deleteByPostIdAndMemberId(postId, memberId);
         return LikeResponse.of(qnaPost.getLikeCount(), false);
     }
 }

--- a/src/main/java/kr/modusplant/domains/communication/qna/domain/model/QnaLike.java
+++ b/src/main/java/kr/modusplant/domains/communication/qna/domain/model/QnaLike.java
@@ -10,6 +10,6 @@ import java.util.UUID;
 @Builder(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class QnaLike {
-    private String qnaPostId;
+    private String postId;
     private UUID memberId;
 }

--- a/src/main/java/kr/modusplant/domains/communication/qna/domain/service/QnaLikeValidationService.java
+++ b/src/main/java/kr/modusplant/domains/communication/qna/domain/service/QnaLikeValidationService.java
@@ -21,27 +21,27 @@ public class QnaLikeValidationService {
     private final SiteMemberRepository memberRepository;
     private final QnaLikeRepository qnaLikeRepository;
 
-    public void validateExistedQnaPostAndMember(String qnaPostId, UUID memberId) {
-        if (qnaPostId == null || memberId == null) {
-            throw new IllegalArgumentException("qnaPostId and memberId must not be null");
-        };
+    public void validateExistedQnaPostAndMember(String postId, UUID memberId) {
+        if (postId == null || memberId == null) {
+            throw new IllegalArgumentException("postId and memberId must not be null");
+        }
 
-        if (!qnaPostRepository.existsById(qnaPostId)) {
-            throw new EntityNotFoundWithUlidException(qnaPostId, QnaPostEntity.class);
+        if (!qnaPostRepository.existsById(postId)) {
+            throw new EntityNotFoundWithUlidException(postId, QnaPostEntity.class);
         }
         if (!memberRepository.existsById(memberId)) {
             throw new EntityExistsWithUuidException(memberId, SiteMemberEntity.class);
         }
     }
 
-    public void validateQnaLikeExists(String qnaPostId, UUID memberId) {
-        if (!qnaLikeRepository.existsByQnaPostIdAndMemberId(qnaPostId, memberId)) {
+    public void validateQnaLikeExists(String postId, UUID memberId) {
+        if (!qnaLikeRepository.existsByPostIdAndMemberId(postId, memberId)) {
             throw new IllegalArgumentException("member not liked status");
         }
     }
 
-    public void validateQnaLikeNotExists(String qnaPostId, UUID memberId) {
-        if (qnaLikeRepository.existsByQnaPostIdAndMemberId(qnaPostId, memberId)) {
+    public void validateQnaLikeNotExists(String postId, UUID memberId) {
+        if (qnaLikeRepository.existsByPostIdAndMemberId(postId, memberId)) {
             throw new IllegalArgumentException("member already liked");
         }
     }

--- a/src/main/java/kr/modusplant/domains/communication/qna/persistence/entity/QnaCommentEntity.java
+++ b/src/main/java/kr/modusplant/domains/communication/qna/persistence/entity/QnaCommentEntity.java
@@ -33,7 +33,7 @@ public class QnaCommentEntity {
     private QnaPostEntity postEntity;
 
     @Id
-    @Column(name = "mate_path", nullable = false, updatable = false)
+    @Column(name = "path", nullable = false, updatable = false)
     private String path;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE}, optional = false)

--- a/src/main/java/kr/modusplant/domains/communication/qna/persistence/entity/QnaLikeEntity.java
+++ b/src/main/java/kr/modusplant/domains/communication/qna/persistence/entity/QnaLikeEntity.java
@@ -21,7 +21,7 @@ import static kr.modusplant.global.vo.SnakeCaseWord.*;
 public class QnaLikeEntity {
     @Id
     @Column(name = SNAKE_POST_ULID, nullable = false)
-    private String qnaPostId;
+    private String postId;
 
     @Id
     @Column(name = SNAKE_MEMB_UUID, nullable = false)
@@ -31,12 +31,12 @@ public class QnaLikeEntity {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    private QnaLikeEntity(String qnaPostId, UUID memberId) {
-        this.qnaPostId = qnaPostId;
+    private QnaLikeEntity(String postId, UUID memberId) {
+        this.postId = postId;
         this.memberId = memberId;
     }
 
-    public static QnaLikeEntity of(String qnaPostId, UUID memberId) {
-        return new QnaLikeEntity(qnaPostId, memberId);
+    public static QnaLikeEntity of(String postId, UUID memberId) {
+        return new QnaLikeEntity(postId, memberId);
     }
 }

--- a/src/main/java/kr/modusplant/domains/communication/qna/persistence/entity/QnaLikeId.java
+++ b/src/main/java/kr/modusplant/domains/communication/qna/persistence/entity/QnaLikeId.java
@@ -12,6 +12,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class QnaLikeId implements Serializable {
-    private String qnaPostId;
+    private String postId;
     private UUID memberId;
 }

--- a/src/main/java/kr/modusplant/domains/communication/qna/persistence/repository/QnaLikeRepository.java
+++ b/src/main/java/kr/modusplant/domains/communication/qna/persistence/repository/QnaLikeRepository.java
@@ -14,8 +14,8 @@ public interface QnaLikeRepository extends JpaRepository<QnaLikeEntity, QnaLikeI
     List<QnaLikeEntity> findByMemberId(UUID memberId);
 
     // 사용자별 Q&A 게시글 좋아요 리스트 조회
-    List<QnaLikeEntity> findByMemberIdAndQnaPostIdIn(UUID memberId, List<String> qnaPostIds);
+    List<QnaLikeEntity> findByMemberIdAndPostIdIn(UUID memberId, List<String> postIds);
 
-    boolean existsByQnaPostIdAndMemberId(String qnaPostId, UUID memberId);
-    void deleteByQnaPostIdAndMemberId(String qnaPostId, UUID memberId);
+    boolean existsByPostIdAndMemberId(String postId, UUID memberId);
+    void deleteByPostIdAndMemberId(String postId, UUID memberId);
 }

--- a/src/main/java/kr/modusplant/domains/communication/tip/app/service/TipLikeApplicationService.java
+++ b/src/main/java/kr/modusplant/domains/communication/tip/app/service/TipLikeApplicationService.java
@@ -20,26 +20,26 @@ public class TipLikeApplicationService {
     private final TipLikeValidationService tipLikeValidationService;
 
     @Transactional
-    public LikeResponse likeTipPost(String tipPostId, UUID memberId) {
-        tipLikeValidationService.validateExistedTipPostAndMember(tipPostId, memberId);
-        tipLikeValidationService.validateTipLikeNotExists(tipPostId, memberId);
+    public LikeResponse likeTipPost(String postId, UUID memberId) {
+        tipLikeValidationService.validateExistedTipPostAndMember(postId, memberId);
+        tipLikeValidationService.validateTipLikeNotExists(postId, memberId);
 
-        TipPostEntity tipPost = tipPostRepository.findById(tipPostId).orElseThrow(() -> new IllegalArgumentException("tip post not found"));
+        TipPostEntity tipPost = tipPostRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("tip post not found"));
         tipPost.increaseLikeCount();
 
-        tipLikeRepository.save(TipLikeEntity.of(tipPostId, memberId));
+        tipLikeRepository.save(TipLikeEntity.of(postId, memberId));
         return LikeResponse.of(tipPost.getLikeCount(), true);
     }
 
     @Transactional
-    public LikeResponse unlikeTipPost(String tipPostId, UUID memberId) {
-        tipLikeValidationService.validateExistedTipPostAndMember(tipPostId, memberId);
-        tipLikeValidationService.validateTipLikeExists(tipPostId, memberId);
+    public LikeResponse unlikeTipPost(String postId, UUID memberId) {
+        tipLikeValidationService.validateExistedTipPostAndMember(postId, memberId);
+        tipLikeValidationService.validateTipLikeExists(postId, memberId);
 
-        TipPostEntity tipPost = tipPostRepository.findById(tipPostId).orElseThrow(() -> new IllegalArgumentException("tip post not found"));
+        TipPostEntity tipPost = tipPostRepository.findById(postId).orElseThrow(() -> new IllegalArgumentException("tip post not found"));
         tipPost.decreaseLikeCount();
 
-        tipLikeRepository.deleteByTipPostIdAndMemberId(tipPostId, memberId);
+        tipLikeRepository.deleteByPostIdAndMemberId(postId, memberId);
         return LikeResponse.of(tipPost.getLikeCount(), false);
     }
 }

--- a/src/main/java/kr/modusplant/domains/communication/tip/domain/model/TipLike.java
+++ b/src/main/java/kr/modusplant/domains/communication/tip/domain/model/TipLike.java
@@ -10,6 +10,6 @@ import java.util.UUID;
 @Builder(access = AccessLevel.PUBLIC)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class TipLike {
-    private String tipPostId;
+    private String postId;
     private UUID memberId;
 }

--- a/src/main/java/kr/modusplant/domains/communication/tip/domain/service/TipLikeValidationService.java
+++ b/src/main/java/kr/modusplant/domains/communication/tip/domain/service/TipLikeValidationService.java
@@ -21,27 +21,27 @@ public class TipLikeValidationService {
     private final SiteMemberRepository memberRepository;
     private final TipLikeRepository tipLikeRepository;
 
-    public void validateExistedTipPostAndMember(String tipPostId, UUID memberId) {
-        if (tipPostId == null || memberId == null) {
-            throw new IllegalArgumentException("tipPostId and memberId must not be null");
-        };
+    public void validateExistedTipPostAndMember(String postId, UUID memberId) {
+        if (postId == null || memberId == null) {
+            throw new IllegalArgumentException("postId and memberId must not be null");
+        }
 
-        if (!tipPostRepository.existsById(tipPostId)) {
-            throw new EntityNotFoundWithUlidException(tipPostId, TipPostEntity.class);
+        if (!tipPostRepository.existsById(postId)) {
+            throw new EntityNotFoundWithUlidException(postId, TipPostEntity.class);
         }
         if (!memberRepository.existsById(memberId)) {
             throw new EntityExistsWithUuidException(memberId, SiteMemberEntity.class);
         }
     }
 
-    public void validateTipLikeExists(String tipPostId, UUID memberId) {
-        if (!tipLikeRepository.existsByTipPostIdAndMemberId(tipPostId, memberId)) {
+    public void validateTipLikeExists(String postId, UUID memberId) {
+        if (!tipLikeRepository.existsByPostIdAndMemberId(postId, memberId)) {
             throw new IllegalArgumentException("member not liked status");
         }
     }
 
-    public void validateTipLikeNotExists(String tipPostId, UUID memberId) {
-        if (tipLikeRepository.existsByTipPostIdAndMemberId(tipPostId, memberId)) {
+    public void validateTipLikeNotExists(String postId, UUID memberId) {
+        if (tipLikeRepository.existsByPostIdAndMemberId(postId, memberId)) {
             throw new IllegalArgumentException("member already liked");
         }
     }

--- a/src/main/java/kr/modusplant/domains/communication/tip/persistence/entity/TipCommentEntity.java
+++ b/src/main/java/kr/modusplant/domains/communication/tip/persistence/entity/TipCommentEntity.java
@@ -33,7 +33,7 @@ public class TipCommentEntity {
     private TipPostEntity postEntity;
 
     @Id
-    @Column(name = "mate_path", nullable = false, updatable = false)
+    @Column(name = "path", nullable = false, updatable = false)
     private String path;
 
     @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE}, optional = false)

--- a/src/main/java/kr/modusplant/domains/communication/tip/persistence/entity/TipLikeEntity.java
+++ b/src/main/java/kr/modusplant/domains/communication/tip/persistence/entity/TipLikeEntity.java
@@ -19,7 +19,7 @@ import static kr.modusplant.global.vo.SnakeCaseWord.*;
 public class TipLikeEntity {
     @Id
     @Column(name = SNAKE_POST_ULID, nullable = false)
-    private String tipPostId;
+    private String postId;
 
     @Id
     @Column(name = SNAKE_MEMB_UUID, nullable = false)
@@ -29,12 +29,12 @@ public class TipLikeEntity {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    private TipLikeEntity(String tipPostId, UUID memberId) {
-        this.tipPostId = tipPostId;
+    private TipLikeEntity(String postId, UUID memberId) {
+        this.postId = postId;
         this.memberId = memberId;
     }
 
-    public static TipLikeEntity of(String tipPostId, UUID memberId) {
-        return new TipLikeEntity(tipPostId, memberId);
+    public static TipLikeEntity of(String postId, UUID memberId) {
+        return new TipLikeEntity(postId, memberId);
     }
 }

--- a/src/main/java/kr/modusplant/domains/communication/tip/persistence/entity/TipLikeId.java
+++ b/src/main/java/kr/modusplant/domains/communication/tip/persistence/entity/TipLikeId.java
@@ -12,6 +12,6 @@ import java.util.UUID;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class TipLikeId implements Serializable {
-    private String tipPostId;
+    private String postId;
     private UUID memberId;
 }

--- a/src/main/java/kr/modusplant/domains/communication/tip/persistence/repository/TipLikeRepository.java
+++ b/src/main/java/kr/modusplant/domains/communication/tip/persistence/repository/TipLikeRepository.java
@@ -14,8 +14,8 @@ public interface TipLikeRepository extends JpaRepository<TipLikeEntity, TipLikeI
     List<TipLikeEntity> findByMemberId(UUID memberId);
 
     // 사용자별 팁 게시글 좋아요 리스트 조회
-    List<TipLikeEntity> findByMemberIdAndTipPostIdIn(UUID memberId, List<String> tipPostIds);
+    List<TipLikeEntity> findByMemberIdAndPostIdIn(UUID memberId, List<String> postIds);
 
-    boolean existsByTipPostIdAndMemberId(String tipPostId, UUID memberId);
-    void deleteByTipPostIdAndMemberId(String tipPostId, UUID memberId);
+    boolean existsByPostIdAndMemberId(String postId, UUID memberId);
+    void deleteByPostIdAndMemberId(String postId, UUID memberId);
 }

--- a/src/test/java/kr/modusplant/domains/communication/conversation/app/service/ConvLikeApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/conversation/app/service/ConvLikeApplicationServiceTest.java
@@ -40,7 +40,7 @@ public class ConvLikeApplicationServiceTest implements SiteMemberEntityTestUtils
     private ConvLikeApplicationService convLikeApplicationService;
 
     private UUID memberId;
-    private String convPostId;
+    private String postId;
 
     @BeforeEach
     void setUp() {
@@ -54,7 +54,7 @@ public class ConvLikeApplicationServiceTest implements SiteMemberEntityTestUtils
                 .category(createTestConvCategoryEntity())
                 .build();
         convPostRepository.save(convPost);
-        convPostId = convPost.getUlid();
+        postId = convPost.getUlid();
 
         siteMemberRepository.flush();
         convPostRepository.flush();
@@ -64,13 +64,13 @@ public class ConvLikeApplicationServiceTest implements SiteMemberEntityTestUtils
     @DisplayName("좋아요 성공")
     void likeConvPost_success() {
         // when
-        LikeResponse response = convLikeApplicationService.likeConvPost(convPostId, memberId);
+        LikeResponse response = convLikeApplicationService.likeConvPost(postId, memberId);
 
         // then
         assertThat(response.liked()).isTrue();
         assertThat(response.likeCount()).isEqualTo(1);
 
-        ConvLikeEntity saved = convLikeRepository.findById(new ConvLikeId(convPostId, memberId)).orElse(null);
+        ConvLikeEntity saved = convLikeRepository.findById(new ConvLikeId(postId, memberId)).orElse(null);
 
         assertThat(saved).isNotNull();
     }
@@ -79,26 +79,26 @@ public class ConvLikeApplicationServiceTest implements SiteMemberEntityTestUtils
     @DisplayName("좋아요 취소 성공")
     void unlikeConvPost_success() {
         // given
-        convLikeApplicationService.likeConvPost(convPostId, memberId);
+        convLikeApplicationService.likeConvPost(postId, memberId);
 
         // when
-        LikeResponse response = convLikeApplicationService.unlikeConvPost(convPostId, memberId);
+        LikeResponse response = convLikeApplicationService.unlikeConvPost(postId, memberId);
 
         // then
         assertThat(response.liked()).isFalse();
         assertThat(response.likeCount()).isEqualTo(0);
-        assertThat(convLikeRepository.existsByConvPostIdAndMemberId(convPostId, memberId)).isFalse();
+        assertThat(convLikeRepository.existsByPostIdAndMemberId(postId, memberId)).isFalse();
     }
 
     @Test
     @DisplayName("이미 좋아요 한 게시글을 또 좋아요 시도할 경우 예외 발생")
     void likeConvPost_duplicateLike_throwsException() {
         // given
-        convLikeApplicationService.likeConvPost(convPostId, memberId);
+        convLikeApplicationService.likeConvPost(postId, memberId);
 
         // when & then
         assertThatThrownBy(() ->
-                convLikeApplicationService.likeConvPost(convPostId, memberId))
+                convLikeApplicationService.likeConvPost(postId, memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("member already liked");
     }
@@ -108,7 +108,7 @@ public class ConvLikeApplicationServiceTest implements SiteMemberEntityTestUtils
     void unlikeConvPost_withoutLike_throwsException() {
         // when & then
         assertThatThrownBy(() ->
-                convLikeApplicationService.unlikeConvPost(convPostId, memberId))
+                convLikeApplicationService.unlikeConvPost(postId, memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("member not liked status");
     }

--- a/src/test/java/kr/modusplant/domains/communication/conversation/common/util/domain/ConvLikeTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/communication/conversation/common/util/domain/ConvLikeTestUtils.java
@@ -5,7 +5,7 @@ import kr.modusplant.domains.member.common.util.domain.SiteMemberTestUtils;
 
 public interface ConvLikeTestUtils extends ConvPostTestUtils, SiteMemberTestUtils {
     ConvLike convLike = ConvLike.builder()
-            .convPostId(convPostWithUlid.getUlid())
+            .postId(convPostWithUlid.getUlid())
             .memberId(memberBasicUserWithUuid.getUuid())
             .build();
 }

--- a/src/test/java/kr/modusplant/domains/communication/conversation/domain/service/ConvLikeValidationServiceTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/conversation/domain/service/ConvLikeValidationServiceTest.java
@@ -52,7 +52,7 @@ class ConvLikeValidationServiceTest {
     @Test
     @DisplayName("좋아요가 존재하지 않을 경우 예외 발생")
     void validateConvLikeExists_notLiked() {
-        when(convLikeRepository.existsByConvPostIdAndMemberId(CONV_POST_ID, MEMBER_ID)).thenReturn(false);
+        when(convLikeRepository.existsByPostIdAndMemberId(CONV_POST_ID, MEMBER_ID)).thenReturn(false);
 
         assertThatThrownBy(() -> validationService.validateConvLikeExists(CONV_POST_ID, MEMBER_ID))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -62,7 +62,7 @@ class ConvLikeValidationServiceTest {
     @Test
     @DisplayName("좋아요가 이미 존재할 경우 예외 발생")
     void validateConvLikeNotExists_alreadyLiked() {
-        when(convLikeRepository.existsByConvPostIdAndMemberId(CONV_POST_ID, MEMBER_ID)).thenReturn(true);
+        when(convLikeRepository.existsByPostIdAndMemberId(CONV_POST_ID, MEMBER_ID)).thenReturn(true);
 
         assertThatThrownBy(() -> validationService.validateConvLikeNotExists(CONV_POST_ID, MEMBER_ID))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/kr/modusplant/domains/communication/conversation/persistence/entity/ConvLikeEntityTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/conversation/persistence/entity/ConvLikeEntityTest.java
@@ -19,16 +19,16 @@ public class ConvLikeEntityTest implements ConvLikeEntityTestUtils {
     @Autowired
     private TestEntityManager entityManager;
 
-    private String convPostId;
+    private String postId;
     private UUID memberId;
 
     @BeforeEach
     void setUp() {
         // given
-        convPostId = convPostWithUlid.getUlid();
+        postId = convPostWithUlid.getUlid();
         memberId = createMemberBasicUserEntityWithUuid().getUuid();
 
-        ConvLikeEntity convLikeEntity = ConvLikeEntity.of(convPostId, memberId);
+        ConvLikeEntity convLikeEntity = ConvLikeEntity.of(postId, memberId);
         entityManager.persistAndFlush(convLikeEntity);
     }
 
@@ -36,11 +36,11 @@ public class ConvLikeEntityTest implements ConvLikeEntityTestUtils {
     @DisplayName("대화 게시글 좋아요")
     void likeConvPost_success () {
         // when
-        ConvLikeEntity convLikeEntity = entityManager.find(ConvLikeEntity.class, new ConvLikeId(convPostId, memberId));
+        ConvLikeEntity convLikeEntity = entityManager.find(ConvLikeEntity.class, new ConvLikeId(postId, memberId));
 
         // then
         assertThat(convLikeEntity).isNotNull();
-        assertThat(convLikeEntity.getConvPostId()).isEqualTo(convPostId);
+        assertThat(convLikeEntity.getPostId()).isEqualTo(postId);
         assertThat(convLikeEntity.getMemberId()).isEqualTo(memberId);
         assertThat(convLikeEntity.getCreatedAt()).isNotNull();
         assertThat(convLikeEntity.getCreatedAt()).isBeforeOrEqualTo(LocalDateTime.now());
@@ -50,13 +50,13 @@ public class ConvLikeEntityTest implements ConvLikeEntityTestUtils {
     @DisplayName("대화 게시글 좋아요 삭제")
     void unlikeConvPost_success() {
         // when
-        ConvLikeEntity convLikeEntity = entityManager.find(ConvLikeEntity.class, new ConvLikeId(convPostId, memberId));
+        ConvLikeEntity convLikeEntity = entityManager.find(ConvLikeEntity.class, new ConvLikeId(postId, memberId));
         entityManager.remove(convLikeEntity);
         entityManager.flush();
         entityManager.clear();
 
         // then
-        ConvLikeEntity deletedEntity = entityManager.find(ConvLikeEntity.class, new ConvLikeId(convPostId, memberId));
+        ConvLikeEntity deletedEntity = entityManager.find(ConvLikeEntity.class, new ConvLikeId(postId, memberId));
         assertThat(deletedEntity).isNull();
     }
 }

--- a/src/test/java/kr/modusplant/domains/communication/conversation/persistence/repository/ConvLikeRepositoryTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/conversation/persistence/repository/ConvLikeRepositoryTest.java
@@ -24,13 +24,13 @@ public class ConvLikeRepositoryTest implements ConvLikeEntityTestUtils {
     @Nested
     @DisplayName("setUp 사용 테스트 그룹")
     class SetupTest {
-        private String convPostId;
+        private String postId;
         private UUID memberId;
 
         @BeforeEach
         void setUp() {
             // given
-            convPostId = convPostWithUlid.getUlid();
+            postId = convPostWithUlid.getUlid();
             memberId = createMemberBasicUserEntityWithUuid().getUuid();
         }
 
@@ -38,12 +38,12 @@ public class ConvLikeRepositoryTest implements ConvLikeEntityTestUtils {
         @DisplayName("대화 게시글 좋아요 후 조회")
         void likeConvPost_success() {
             // when
-            convLikeRepository.save(ConvLikeEntity.of(convPostId, memberId));
+            convLikeRepository.save(ConvLikeEntity.of(postId, memberId));
 
             // then
-            Optional<ConvLikeEntity> convLikeEntity = convLikeRepository.findById(new ConvLikeId(convPostId, memberId));
+            Optional<ConvLikeEntity> convLikeEntity = convLikeRepository.findById(new ConvLikeId(postId, memberId));
             assertThat(convLikeEntity).isPresent();
-            assertThat(convLikeEntity.get().getConvPostId()).isEqualTo(convPostId);
+            assertThat(convLikeEntity.get().getPostId()).isEqualTo(postId);
             assertThat(convLikeEntity.get().getMemberId()).isEqualTo(memberId);
             assertThat(convLikeEntity.get().getCreatedAt()).isNotNull();
         }
@@ -52,10 +52,10 @@ public class ConvLikeRepositoryTest implements ConvLikeEntityTestUtils {
         @DisplayName("특정 사용자 대화 게시글 좋아요 여부 확인")
         void isLikedByMember_returnsTrue() {
             // given
-            convLikeRepository.save(ConvLikeEntity.of(convPostId, memberId));
+            convLikeRepository.save(ConvLikeEntity.of(postId, memberId));
 
             // when
-            boolean isLiked = convLikeRepository.existsByConvPostIdAndMemberId(convPostId, memberId);
+            boolean isLiked = convLikeRepository.existsByPostIdAndMemberId(postId, memberId);
 
             // then
             assertThat(isLiked).isTrue();
@@ -65,13 +65,13 @@ public class ConvLikeRepositoryTest implements ConvLikeEntityTestUtils {
         @DisplayName("대화 게시글 좋아요 취소")
         void unlikeConvPost_success() {
             // given
-            convLikeRepository.save(ConvLikeEntity.of(convPostId, memberId));
+            convLikeRepository.save(ConvLikeEntity.of(postId, memberId));
 
             // when
-            convLikeRepository.deleteByConvPostIdAndMemberId(convPostId, memberId);
+            convLikeRepository.deleteByPostIdAndMemberId(postId, memberId);
 
             // then
-            assertThat(convLikeRepository.existsByConvPostIdAndMemberId(convPostId, memberId)).isFalse();
+            assertThat(convLikeRepository.existsByPostIdAndMemberId(postId, memberId)).isFalse();
         }
     }
 
@@ -80,23 +80,23 @@ public class ConvLikeRepositoryTest implements ConvLikeEntityTestUtils {
     void findConvLikesByMemberId() {
         // given
         UUID memberId = createMemberBasicUserEntityWithUuid().getUuid();
-        List<String> convPostIds = List.of(
+        List<String> postIds = List.of(
                 "TEST_CONV_POST_ID_001",
                 "TEST_CONV_POST_ID_002",
                 "TEST_CONV_POST_ID_003"
         );
 
         convLikeRepository.saveAll(List.of(
-                ConvLikeEntity.of(convPostIds.get(0), memberId),
-                ConvLikeEntity.of(convPostIds.get(1), memberId),
-                ConvLikeEntity.of(convPostIds.get(2), memberId)
+                ConvLikeEntity.of(postIds.get(0), memberId),
+                ConvLikeEntity.of(postIds.get(1), memberId),
+                ConvLikeEntity.of(postIds.get(2), memberId)
         ));
         convLikeRepository.flush();
 
         // when
         List<ConvLikeEntity> convLikeList = convLikeRepository.findByMemberId(memberId);
 
-        assertThat(convLikeList).hasSize(convPostIds.size());
+        assertThat(convLikeList).hasSize(postIds.size());
     }
 
     @Test
@@ -104,29 +104,29 @@ public class ConvLikeRepositoryTest implements ConvLikeEntityTestUtils {
     void findConvLikesByMemberIdAndPostIds() {
         // given
         UUID memberId = createMemberBasicUserEntityWithUuid().getUuid();
-        List<String> convPostIds = List.of(
+        List<String> postIds = List.of(
                 "TEST_CONV_POST_ID_001",
                 "TEST_CONV_POST_ID_002",
                 "TEST_CONV_POST_ID_003"
         );
 
         convLikeRepository.saveAll(List.of(
-                ConvLikeEntity.of(convPostIds.get(0), memberId),
-                ConvLikeEntity.of(convPostIds.get(1), memberId),
-                ConvLikeEntity.of(convPostIds.get(2), memberId)
+                ConvLikeEntity.of(postIds.get(0), memberId),
+                ConvLikeEntity.of(postIds.get(1), memberId),
+                ConvLikeEntity.of(postIds.get(2), memberId)
         ));
         convLikeRepository.flush();
 
         // when
-        List<ConvLikeEntity> convLikeList = convLikeRepository.findByMemberIdAndConvPostIdIn(memberId, convPostIds);
+        List<ConvLikeEntity> convLikeList = convLikeRepository.findByMemberIdAndPostIdIn(memberId, postIds);
 
         // then
-        List<String> likedConvPostIds = convLikeList.stream()
-                .map(ConvLikeEntity::getConvPostId)
+        List<String> likedPostIds = convLikeList.stream()
+                .map(ConvLikeEntity::getPostId)
                 .toList();
 
-        assertThat(convLikeList).size().isEqualTo(convPostIds.size());
-        assertThat(likedConvPostIds).hasSize(convPostIds.size());
-        assertThat(likedConvPostIds).containsExactlyInAnyOrder(convPostIds.get(0), convPostIds.get(1), convPostIds.get(2));
+        assertThat(convLikeList).size().isEqualTo(postIds.size());
+        assertThat(likedPostIds).hasSize(postIds.size());
+        assertThat(likedPostIds).containsExactlyInAnyOrder(postIds.get(0), postIds.get(1), postIds.get(2));
     }
 }

--- a/src/test/java/kr/modusplant/domains/communication/qna/app/service/QnaLikeApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/qna/app/service/QnaLikeApplicationServiceTest.java
@@ -40,7 +40,7 @@ public class QnaLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
     private QnaLikeApplicationService qnaLikeApplicationService;
 
     private UUID memberId;
-    private String qnaPostId;
+    private String postId;
 
     @BeforeEach
     void setUp() {
@@ -54,7 +54,7 @@ public class QnaLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
                 .category(createTestQnaCategoryEntity())
                 .build();
         qnaPostRepository.save(qnaPost);
-        qnaPostId = qnaPost.getUlid();
+        postId = qnaPost.getUlid();
 
         siteMemberRepository.flush();
         qnaPostRepository.flush();
@@ -64,13 +64,13 @@ public class QnaLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
     @DisplayName("좋아요 성공")
     void likeQnaPost_success() {
         // when
-        LikeResponse response = qnaLikeApplicationService.likeQnaPost(qnaPostId, memberId);
+        LikeResponse response = qnaLikeApplicationService.likeQnaPost(postId, memberId);
 
         // then
         assertThat(response.liked()).isTrue();
         assertThat(response.likeCount()).isEqualTo(1);
 
-        QnaLikeEntity saved = qnaLikeRepository.findById(new QnaLikeId(qnaPostId, memberId)).orElse(null);
+        QnaLikeEntity saved = qnaLikeRepository.findById(new QnaLikeId(postId, memberId)).orElse(null);
 
         assertThat(saved).isNotNull();
     }
@@ -79,26 +79,26 @@ public class QnaLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
     @DisplayName("좋아요 취소 성공")
     void unlikeQnaPost_success() {
         // given
-        qnaLikeApplicationService.likeQnaPost(qnaPostId, memberId);
+        qnaLikeApplicationService.likeQnaPost(postId, memberId);
 
         // when
-        LikeResponse response = qnaLikeApplicationService.unlikeQnaPost(qnaPostId, memberId);
+        LikeResponse response = qnaLikeApplicationService.unlikeQnaPost(postId, memberId);
 
         // then
         assertThat(response.liked()).isFalse();
         assertThat(response.likeCount()).isEqualTo(0);
-        assertThat(qnaLikeRepository.existsByQnaPostIdAndMemberId(qnaPostId, memberId)).isFalse();
+        assertThat(qnaLikeRepository.existsByPostIdAndMemberId(postId, memberId)).isFalse();
     }
 
     @Test
     @DisplayName("이미 좋아요 한 게시글을 또 좋아요 시도할 경우 예외 발생")
     void likeQnaPost_duplicateLike_throwsException() {
         // given
-        qnaLikeApplicationService.likeQnaPost(qnaPostId, memberId);
+        qnaLikeApplicationService.likeQnaPost(postId, memberId);
 
         // when & then
         assertThatThrownBy(() ->
-                qnaLikeApplicationService.likeQnaPost(qnaPostId, memberId))
+                qnaLikeApplicationService.likeQnaPost(postId, memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("member already liked");
     }
@@ -108,7 +108,7 @@ public class QnaLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
     void unlikeQnaPost_withoutLike_throwsException() {
         // when & then
         assertThatThrownBy(() ->
-                qnaLikeApplicationService.unlikeQnaPost(qnaPostId, memberId))
+                qnaLikeApplicationService.unlikeQnaPost(postId, memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("member not liked status");
     }

--- a/src/test/java/kr/modusplant/domains/communication/qna/common/util/domain/QnaLikeTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/communication/qna/common/util/domain/QnaLikeTestUtils.java
@@ -5,7 +5,7 @@ import kr.modusplant.domains.member.common.util.domain.SiteMemberTestUtils;
 
 public interface QnaLikeTestUtils extends QnaPostTestUtils, SiteMemberTestUtils {
     QnaLike qnaLike = QnaLike.builder()
-            .qnaPostId(qnaPostWithUlid.getUlid())
+            .postId(qnaPostWithUlid.getUlid())
             .memberId(memberBasicUserWithUuid.getUuid())
             .build();
 }

--- a/src/test/java/kr/modusplant/domains/communication/qna/domain/service/QnaLikeValidationServiceTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/qna/domain/service/QnaLikeValidationServiceTest.java
@@ -52,7 +52,7 @@ class QnaLikeValidationServiceTest {
     @Test
     @DisplayName("좋아요가 존재하지 않을 경우 예외 발생")
     void validateQnaLikeExists_notLiked() {
-        when(qnaLikeRepository.existsByQnaPostIdAndMemberId(QNA_POST_ID, MEMBER_ID)).thenReturn(false);
+        when(qnaLikeRepository.existsByPostIdAndMemberId(QNA_POST_ID, MEMBER_ID)).thenReturn(false);
 
         assertThatThrownBy(() -> validationService.validateQnaLikeExists(QNA_POST_ID, MEMBER_ID))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -62,7 +62,7 @@ class QnaLikeValidationServiceTest {
     @Test
     @DisplayName("좋아요가 이미 존재할 경우 예외 발생")
     void validateQnaLikeNotExists_alreadyLiked() {
-        when(qnaLikeRepository.existsByQnaPostIdAndMemberId(QNA_POST_ID, MEMBER_ID)).thenReturn(true);
+        when(qnaLikeRepository.existsByPostIdAndMemberId(QNA_POST_ID, MEMBER_ID)).thenReturn(true);
 
         assertThatThrownBy(() -> validationService.validateQnaLikeNotExists(QNA_POST_ID, MEMBER_ID))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/kr/modusplant/domains/communication/qna/persistence/entity/QnaLikeEntityTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/qna/persistence/entity/QnaLikeEntityTest.java
@@ -19,16 +19,16 @@ public class QnaLikeEntityTest implements QnaLikeEntityTestUtils {
     @Autowired
     private TestEntityManager entityManager;
 
-    private String qnaPostId;
+    private String postId;
     private UUID memberId;
 
     @BeforeEach
     void setUp() {
         // given
-        qnaPostId = qnaPostWithUlid.getUlid();
+        postId = qnaPostWithUlid.getUlid();
         memberId = createMemberBasicUserEntityWithUuid().getUuid();
 
-        QnaLikeEntity qnaLikeEntity = QnaLikeEntity.of(qnaPostId, memberId);
+        QnaLikeEntity qnaLikeEntity = QnaLikeEntity.of(postId, memberId);
         entityManager.persistAndFlush(qnaLikeEntity);
     }
 
@@ -36,11 +36,11 @@ public class QnaLikeEntityTest implements QnaLikeEntityTestUtils {
     @DisplayName("Q&A 게시글 좋아요")
     void likeQnaPost_success () {
         // when
-        QnaLikeEntity qnaLikeEntity = entityManager.find(QnaLikeEntity.class, new QnaLikeId(qnaPostId, memberId));
+        QnaLikeEntity qnaLikeEntity = entityManager.find(QnaLikeEntity.class, new QnaLikeId(postId, memberId));
 
         // then
         assertThat(qnaLikeEntity).isNotNull();
-        assertThat(qnaLikeEntity.getQnaPostId()).isEqualTo(qnaPostId);
+        assertThat(qnaLikeEntity.getPostId()).isEqualTo(postId);
         assertThat(qnaLikeEntity.getMemberId()).isEqualTo(memberId);
         assertThat(qnaLikeEntity.getCreatedAt()).isNotNull();
         assertThat(qnaLikeEntity.getCreatedAt()).isBeforeOrEqualTo(LocalDateTime.now());
@@ -50,13 +50,13 @@ public class QnaLikeEntityTest implements QnaLikeEntityTestUtils {
     @DisplayName("Q&A 게시글 좋아요 삭제")
     void unlikeQnaPost_success() {
         // when
-        QnaLikeEntity qnaLikeEntity = entityManager.find(QnaLikeEntity.class, new QnaLikeId(qnaPostId, memberId));
+        QnaLikeEntity qnaLikeEntity = entityManager.find(QnaLikeEntity.class, new QnaLikeId(postId, memberId));
         entityManager.remove(qnaLikeEntity);
         entityManager.flush();
         entityManager.clear();
 
         // then
-        QnaLikeEntity deletedEntity = entityManager.find(QnaLikeEntity.class, new QnaLikeId(qnaPostId, memberId));
+        QnaLikeEntity deletedEntity = entityManager.find(QnaLikeEntity.class, new QnaLikeId(postId, memberId));
         assertThat(deletedEntity).isNull();
     }
 }

--- a/src/test/java/kr/modusplant/domains/communication/qna/persistence/repository/QnaLikeRepositoryTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/qna/persistence/repository/QnaLikeRepositoryTest.java
@@ -24,13 +24,13 @@ public class QnaLikeRepositoryTest implements QnaLikeEntityTestUtils {
     @Nested
     @DisplayName("setUp 사용 테스트 그룹")
     class SetupTest {
-        private String qnaPostId;
+        private String postId;
         private UUID memberId;
 
         @BeforeEach
         void setUp() {
             // given
-            qnaPostId = qnaPostWithUlid.getUlid();
+            postId = qnaPostWithUlid.getUlid();
             memberId = createMemberBasicUserEntityWithUuid().getUuid();
         }
 
@@ -38,12 +38,12 @@ public class QnaLikeRepositoryTest implements QnaLikeEntityTestUtils {
         @DisplayName("Q&A 게시글 좋아요 후 조회")
         void likeQnaPost_success() {
             // when
-            qnaLikeRepository.save(QnaLikeEntity.of(qnaPostId, memberId));
+            qnaLikeRepository.save(QnaLikeEntity.of(postId, memberId));
 
             // then
-            Optional<QnaLikeEntity> qnaLikeEntity = qnaLikeRepository.findById(new QnaLikeId(qnaPostId, memberId));
+            Optional<QnaLikeEntity> qnaLikeEntity = qnaLikeRepository.findById(new QnaLikeId(postId, memberId));
             assertThat(qnaLikeEntity).isPresent();
-            assertThat(qnaLikeEntity.get().getQnaPostId()).isEqualTo(qnaPostId);
+            assertThat(qnaLikeEntity.get().getPostId()).isEqualTo(postId);
             assertThat(qnaLikeEntity.get().getMemberId()).isEqualTo(memberId);
             assertThat(qnaLikeEntity.get().getCreatedAt()).isNotNull();
         }
@@ -52,10 +52,10 @@ public class QnaLikeRepositoryTest implements QnaLikeEntityTestUtils {
         @DisplayName("특정 사용자 Q&A 게시글 좋아요 여부 확인")
         void isLikedByMember_returnsTrue() {
             // given
-            qnaLikeRepository.save(QnaLikeEntity.of(qnaPostId, memberId));
+            qnaLikeRepository.save(QnaLikeEntity.of(postId, memberId));
 
             // when
-            boolean isLiked = qnaLikeRepository.existsByQnaPostIdAndMemberId(qnaPostId, memberId);
+            boolean isLiked = qnaLikeRepository.existsByPostIdAndMemberId(postId, memberId);
 
             // then
             assertThat(isLiked).isTrue();
@@ -65,13 +65,13 @@ public class QnaLikeRepositoryTest implements QnaLikeEntityTestUtils {
         @DisplayName("Q&A 게시글 좋아요 취소")
         void unlikeQnaPost_success() {
             // given
-            qnaLikeRepository.save(QnaLikeEntity.of(qnaPostId, memberId));
+            qnaLikeRepository.save(QnaLikeEntity.of(postId, memberId));
 
             // when
-            qnaLikeRepository.deleteByQnaPostIdAndMemberId(qnaPostId, memberId);
+            qnaLikeRepository.deleteByPostIdAndMemberId(postId, memberId);
 
             // then
-            assertThat(qnaLikeRepository.existsByQnaPostIdAndMemberId(qnaPostId, memberId)).isFalse();
+            assertThat(qnaLikeRepository.existsByPostIdAndMemberId(postId, memberId)).isFalse();
         }
     }
 
@@ -80,23 +80,23 @@ public class QnaLikeRepositoryTest implements QnaLikeEntityTestUtils {
     void findQnaLikesByMemberId() {
         // given
         UUID memberId = createMemberBasicUserEntityWithUuid().getUuid();
-        List<String> qnaPostIds = List.of(
+        List<String> postIds = List.of(
                 "TEST_QNA_POST_ID_001",
                 "TEST_QNA_POST_ID_002",
                 "TEST_QNA_POST_ID_003"
         );
 
         qnaLikeRepository.saveAll(List.of(
-                QnaLikeEntity.of(qnaPostIds.get(0), memberId),
-                QnaLikeEntity.of(qnaPostIds.get(1), memberId),
-                QnaLikeEntity.of(qnaPostIds.get(2), memberId)
+                QnaLikeEntity.of(postIds.get(0), memberId),
+                QnaLikeEntity.of(postIds.get(1), memberId),
+                QnaLikeEntity.of(postIds.get(2), memberId)
         ));
         qnaLikeRepository.flush();
 
         // when
         List<QnaLikeEntity> qnaLikeList = qnaLikeRepository.findByMemberId(memberId);
 
-        assertThat(qnaLikeList).hasSize(qnaPostIds.size());
+        assertThat(qnaLikeList).hasSize(postIds.size());
     }
 
     @Test
@@ -104,29 +104,29 @@ public class QnaLikeRepositoryTest implements QnaLikeEntityTestUtils {
     void findQnaLikesByMemberIdAndPostIds() {
         // given
         UUID memberId = createMemberBasicUserEntityWithUuid().getUuid();
-        List<String> qnaPostIds = List.of(
+        List<String> postIds = List.of(
                 "TEST_QNA_POST_ID_001",
                 "TEST_QNA_POST_ID_002",
                 "TEST_QNA_POST_ID_003"
         );
 
         qnaLikeRepository.saveAll(List.of(
-                QnaLikeEntity.of(qnaPostIds.get(0), memberId),
-                QnaLikeEntity.of(qnaPostIds.get(1), memberId),
-                QnaLikeEntity.of(qnaPostIds.get(2), memberId)
+                QnaLikeEntity.of(postIds.get(0), memberId),
+                QnaLikeEntity.of(postIds.get(1), memberId),
+                QnaLikeEntity.of(postIds.get(2), memberId)
         ));
         qnaLikeRepository.flush();
 
         // when
-        List<QnaLikeEntity> qnaLikeList = qnaLikeRepository.findByMemberIdAndQnaPostIdIn(memberId, qnaPostIds);
+        List<QnaLikeEntity> qnaLikeList = qnaLikeRepository.findByMemberIdAndPostIdIn(memberId, postIds);
 
         // then
-        List<String> likedQnaPostIds = qnaLikeList.stream()
-                .map(QnaLikeEntity::getQnaPostId)
+        List<String> likedPostIds = qnaLikeList.stream()
+                .map(QnaLikeEntity::getPostId)
                 .toList();
 
-        assertThat(qnaLikeList).size().isEqualTo(qnaPostIds.size());
-        assertThat(likedQnaPostIds).hasSize(qnaPostIds.size());
-        assertThat(likedQnaPostIds).containsExactlyInAnyOrder(qnaPostIds.get(0), qnaPostIds.get(1), qnaPostIds.get(2));
+        assertThat(qnaLikeList).size().isEqualTo(postIds.size());
+        assertThat(likedPostIds).hasSize(postIds.size());
+        assertThat(likedPostIds).containsExactlyInAnyOrder(postIds.get(0), postIds.get(1), postIds.get(2));
     }
 }

--- a/src/test/java/kr/modusplant/domains/communication/tip/app/service/TipLikeApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/tip/app/service/TipLikeApplicationServiceTest.java
@@ -40,7 +40,7 @@ public class TipLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
     private TipLikeApplicationService tipLikeApplicationService;
 
     private UUID memberId;
-    private String tipPostId;
+    private String postId;
 
     @BeforeEach
     void setUp() {
@@ -54,7 +54,7 @@ public class TipLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
                 .category(createTestTipCategoryEntity())
                 .build();
         tipPostRepository.save(tipPost);
-        tipPostId = tipPost.getUlid();
+        postId = tipPost.getUlid();
 
         siteMemberRepository.flush();
         tipPostRepository.flush();
@@ -64,13 +64,13 @@ public class TipLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
     @DisplayName("좋아요 성공")
     void likeTipPost_success() {
         // when
-        LikeResponse response = tipLikeApplicationService.likeTipPost(tipPostId, memberId);
+        LikeResponse response = tipLikeApplicationService.likeTipPost(postId, memberId);
 
         // then
         assertThat(response.liked()).isTrue();
         assertThat(response.likeCount()).isEqualTo(1);
 
-        TipLikeEntity saved = tipLikeRepository.findById(new TipLikeId(tipPostId, memberId)).orElse(null);
+        TipLikeEntity saved = tipLikeRepository.findById(new TipLikeId(postId, memberId)).orElse(null);
 
         assertThat(saved).isNotNull();
     }
@@ -79,26 +79,26 @@ public class TipLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
     @DisplayName("좋아요 취소 성공")
     void unlikeTipPost_success() {
         // given
-        tipLikeApplicationService.likeTipPost(tipPostId, memberId);
+        tipLikeApplicationService.likeTipPost(postId, memberId);
 
         // when
-        LikeResponse response = tipLikeApplicationService.unlikeTipPost(tipPostId, memberId);
+        LikeResponse response = tipLikeApplicationService.unlikeTipPost(postId, memberId);
 
         // then
         assertThat(response.liked()).isFalse();
         assertThat(response.likeCount()).isEqualTo(0);
-        assertThat(tipLikeRepository.existsByTipPostIdAndMemberId(tipPostId, memberId)).isFalse();
+        assertThat(tipLikeRepository.existsByPostIdAndMemberId(postId, memberId)).isFalse();
     }
 
     @Test
     @DisplayName("이미 좋아요 한 게시글을 또 좋아요 시도할 경우 예외 발생")
     void likeTipPost_duplicateLike_throwsException() {
         // given
-        tipLikeApplicationService.likeTipPost(tipPostId, memberId);
+        tipLikeApplicationService.likeTipPost(postId, memberId);
 
         // when & then
         assertThatThrownBy(() ->
-                tipLikeApplicationService.likeTipPost(tipPostId, memberId))
+                tipLikeApplicationService.likeTipPost(postId, memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("member already liked");
     }
@@ -108,7 +108,7 @@ public class TipLikeApplicationServiceTest implements SiteMemberEntityTestUtils,
     void unlikeTipPost_withoutLike_throwsException() {
         // when & then
         assertThatThrownBy(() ->
-                tipLikeApplicationService.unlikeTipPost(tipPostId, memberId))
+                tipLikeApplicationService.unlikeTipPost(postId, memberId))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("member not liked status");
     }

--- a/src/test/java/kr/modusplant/domains/communication/tip/common/util/domain/TipLikeTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/communication/tip/common/util/domain/TipLikeTestUtils.java
@@ -5,7 +5,7 @@ import kr.modusplant.domains.member.common.util.domain.SiteMemberTestUtils;
 
 public interface TipLikeTestUtils extends TipPostTestUtils, SiteMemberTestUtils {
     TipLike tipLike = TipLike.builder()
-            .tipPostId(tipPostWithUlid.getUlid())
+            .postId(tipPostWithUlid.getUlid())
             .memberId(memberBasicUserWithUuid.getUuid())
             .build();
 }

--- a/src/test/java/kr/modusplant/domains/communication/tip/domain/service/TipLikeValidationServiceTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/tip/domain/service/TipLikeValidationServiceTest.java
@@ -52,7 +52,7 @@ class TipLikeValidationServiceTest {
     @Test
     @DisplayName("좋아요가 존재하지 않을 경우 예외 발생")
     void validateTipLikeExists_notLiked() {
-        when(tipLikeRepository.existsByTipPostIdAndMemberId(TIP_POST_ID, MEMBER_ID)).thenReturn(false);
+        when(tipLikeRepository.existsByPostIdAndMemberId(TIP_POST_ID, MEMBER_ID)).thenReturn(false);
 
         assertThatThrownBy(() -> validationService.validateTipLikeExists(TIP_POST_ID, MEMBER_ID))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -62,7 +62,7 @@ class TipLikeValidationServiceTest {
     @Test
     @DisplayName("좋아요가 이미 존재할 경우 예외 발생")
     void validateTipLikeNotExists_alreadyLiked() {
-        when(tipLikeRepository.existsByTipPostIdAndMemberId(TIP_POST_ID, MEMBER_ID)).thenReturn(true);
+        when(tipLikeRepository.existsByPostIdAndMemberId(TIP_POST_ID, MEMBER_ID)).thenReturn(true);
 
         assertThatThrownBy(() -> validationService.validateTipLikeNotExists(TIP_POST_ID, MEMBER_ID))
                 .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/kr/modusplant/domains/communication/tip/persistence/entity/TipLikeEntityTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/tip/persistence/entity/TipLikeEntityTest.java
@@ -19,16 +19,16 @@ public class TipLikeEntityTest implements TipLikeEntityTestUtils {
     @Autowired
     private TestEntityManager entityManager;
 
-    private String tipPostId;
+    private String postId;
     private UUID memberId;
 
     @BeforeEach
     void setUp() {
         // given
-        tipPostId = tipPostWithUlid.getUlid();
+        postId = tipPostWithUlid.getUlid();
         memberId = createMemberBasicUserEntityWithUuid().getUuid();
 
-        TipLikeEntity tipLikeEntity = TipLikeEntity.of(tipPostId, memberId);
+        TipLikeEntity tipLikeEntity = TipLikeEntity.of(postId, memberId);
         entityManager.persistAndFlush(tipLikeEntity);
     }
 
@@ -36,11 +36,11 @@ public class TipLikeEntityTest implements TipLikeEntityTestUtils {
     @DisplayName("팁 게시글 좋아요")
     void likeTipPost_success () {
         // when
-        TipLikeEntity tipLikeEntity = entityManager.find(TipLikeEntity.class, new TipLikeId(tipPostId, memberId));
+        TipLikeEntity tipLikeEntity = entityManager.find(TipLikeEntity.class, new TipLikeId(postId, memberId));
 
         // then
         assertThat(tipLikeEntity).isNotNull();
-        assertThat(tipLikeEntity.getTipPostId()).isEqualTo(tipPostId);
+        assertThat(tipLikeEntity.getPostId()).isEqualTo(postId);
         assertThat(tipLikeEntity.getMemberId()).isEqualTo(memberId);
         assertThat(tipLikeEntity.getCreatedAt()).isNotNull();
         assertThat(tipLikeEntity.getCreatedAt()).isBeforeOrEqualTo(LocalDateTime.now());
@@ -50,13 +50,13 @@ public class TipLikeEntityTest implements TipLikeEntityTestUtils {
     @DisplayName("팁 게시글 좋아요 삭제")
     void unlikeTipPost_success() {
         // when
-        TipLikeEntity tipLikeEntity = entityManager.find(TipLikeEntity.class, new TipLikeId(tipPostId, memberId));
+        TipLikeEntity tipLikeEntity = entityManager.find(TipLikeEntity.class, new TipLikeId(postId, memberId));
         entityManager.remove(tipLikeEntity);
         entityManager.flush();
         entityManager.clear();
 
         // then
-        TipLikeEntity deletedEntity = entityManager.find(TipLikeEntity.class, new TipLikeId(tipPostId, memberId));
+        TipLikeEntity deletedEntity = entityManager.find(TipLikeEntity.class, new TipLikeId(postId, memberId));
         assertThat(deletedEntity).isNull();
     }
 }

--- a/src/test/java/kr/modusplant/domains/communication/tip/persistence/repository/TipLikeRepositoryTest.java
+++ b/src/test/java/kr/modusplant/domains/communication/tip/persistence/repository/TipLikeRepositoryTest.java
@@ -24,13 +24,13 @@ public class TipLikeRepositoryTest implements TipLikeEntityTestUtils {
     @Nested
     @DisplayName("setUp 사용 테스트 그룹")
     class SetupTest {
-        private String tipPostId;
+        private String postId;
         private UUID memberId;
 
         @BeforeEach
         void setUp() {
             // given
-            tipPostId = tipPostWithUlid.getUlid();
+            postId = tipPostWithUlid.getUlid();
             memberId = createMemberBasicUserEntityWithUuid().getUuid();
         }
 
@@ -38,12 +38,12 @@ public class TipLikeRepositoryTest implements TipLikeEntityTestUtils {
         @DisplayName("팁 게시글 좋아요 후 조회")
         void likeTipPost_success() {
             // when
-            tipLikeRepository.save(TipLikeEntity.of(tipPostId, memberId));
+            tipLikeRepository.save(TipLikeEntity.of(postId, memberId));
 
             // then
-            Optional<TipLikeEntity> tipLikeEntity = tipLikeRepository.findById(new TipLikeId(tipPostId, memberId));
+            Optional<TipLikeEntity> tipLikeEntity = tipLikeRepository.findById(new TipLikeId(postId, memberId));
             assertThat(tipLikeEntity).isPresent();
-            assertThat(tipLikeEntity.get().getTipPostId()).isEqualTo(tipPostId);
+            assertThat(tipLikeEntity.get().getPostId()).isEqualTo(postId);
             assertThat(tipLikeEntity.get().getMemberId()).isEqualTo(memberId);
             assertThat(tipLikeEntity.get().getCreatedAt()).isNotNull();
         }
@@ -52,10 +52,10 @@ public class TipLikeRepositoryTest implements TipLikeEntityTestUtils {
         @DisplayName("특정 사용자 팁 게시글 좋아요 여부 확인")
         void isLikedByMember_returnsTrue() {
             // given
-            tipLikeRepository.save(TipLikeEntity.of(tipPostId, memberId));
+            tipLikeRepository.save(TipLikeEntity.of(postId, memberId));
 
             // when
-            boolean isLiked = tipLikeRepository.existsByTipPostIdAndMemberId(tipPostId, memberId);
+            boolean isLiked = tipLikeRepository.existsByPostIdAndMemberId(postId, memberId);
 
             // then
             assertThat(isLiked).isTrue();
@@ -65,13 +65,13 @@ public class TipLikeRepositoryTest implements TipLikeEntityTestUtils {
         @DisplayName("팁 게시글 좋아요 취소")
         void unlikeTipPost_success() {
             // given
-            tipLikeRepository.save(TipLikeEntity.of(tipPostId, memberId));
+            tipLikeRepository.save(TipLikeEntity.of(postId, memberId));
 
             // when
-            tipLikeRepository.deleteByTipPostIdAndMemberId(tipPostId, memberId);
+            tipLikeRepository.deleteByPostIdAndMemberId(postId, memberId);
 
             // then
-            assertThat(tipLikeRepository.existsByTipPostIdAndMemberId(tipPostId, memberId)).isFalse();
+            assertThat(tipLikeRepository.existsByPostIdAndMemberId(postId, memberId)).isFalse();
         }
     }
 
@@ -80,23 +80,23 @@ public class TipLikeRepositoryTest implements TipLikeEntityTestUtils {
     void findTipLikesByMemberId() {
         // given
         UUID memberId = createMemberBasicUserEntityWithUuid().getUuid();
-        List<String> tipPostIds = List.of(
+        List<String> postIds = List.of(
                 "TEST_TIP_POST_ID_001",
                 "TEST_TIP_POST_ID_002",
                 "TEST_TIP_POST_ID_003"
         );
 
         tipLikeRepository.saveAll(List.of(
-                TipLikeEntity.of(tipPostIds.get(0), memberId),
-                TipLikeEntity.of(tipPostIds.get(1), memberId),
-                TipLikeEntity.of(tipPostIds.get(2), memberId)
+                TipLikeEntity.of(postIds.get(0), memberId),
+                TipLikeEntity.of(postIds.get(1), memberId),
+                TipLikeEntity.of(postIds.get(2), memberId)
         ));
         tipLikeRepository.flush();
 
         // when
         List<TipLikeEntity> tipLikeList = tipLikeRepository.findByMemberId(memberId);
 
-        assertThat(tipLikeList).hasSize(tipPostIds.size());
+        assertThat(tipLikeList).hasSize(postIds.size());
     }
 
     @Test
@@ -104,29 +104,29 @@ public class TipLikeRepositoryTest implements TipLikeEntityTestUtils {
     void findTipLikesByMemberIdAndPostIds() {
         // given
         UUID memberId = createMemberBasicUserEntityWithUuid().getUuid();
-        List<String> tipPostIds = List.of(
+        List<String> postIds = List.of(
                 "TEST_TIP_POST_ID_001",
                 "TEST_TIP_POST_ID_002",
                 "TEST_TIP_POST_ID_003"
         );
 
         tipLikeRepository.saveAll(List.of(
-                TipLikeEntity.of(tipPostIds.get(0), memberId),
-                TipLikeEntity.of(tipPostIds.get(1), memberId),
-                TipLikeEntity.of(tipPostIds.get(2), memberId)
+                TipLikeEntity.of(postIds.get(0), memberId),
+                TipLikeEntity.of(postIds.get(1), memberId),
+                TipLikeEntity.of(postIds.get(2), memberId)
         ));
         tipLikeRepository.flush();
 
         // when
-        List<TipLikeEntity> tipLikeList = tipLikeRepository.findByMemberIdAndTipPostIdIn(memberId, tipPostIds);
+        List<TipLikeEntity> tipLikeList = tipLikeRepository.findByMemberIdAndPostIdIn(memberId, postIds);
 
         // then
-        List<String> likedTipPostIds = tipLikeList.stream()
-                .map(TipLikeEntity::getTipPostId)
+        List<String> likedPostIds = tipLikeList.stream()
+                .map(TipLikeEntity::getPostId)
                 .toList();
 
-        assertThat(tipLikeList).size().isEqualTo(tipPostIds.size());
-        assertThat(likedTipPostIds).hasSize(tipPostIds.size());
-        assertThat(likedTipPostIds).containsExactlyInAnyOrder(tipPostIds.get(0), tipPostIds.get(1), tipPostIds.get(2));
+        assertThat(tipLikeList).size().isEqualTo(postIds.size());
+        assertThat(likedPostIds).hasSize(postIds.size());
+        assertThat(likedPostIds).containsExactlyInAnyOrder(postIds.get(0), postIds.get(1), postIds.get(2));
     }
 }


### PR DESCRIPTION
도메인 패키지 내부의 필드명이
1. DB 테이블에서의 필드명과 일치되도록 하고
2. 프로젝트 내부에서 일관되게 사용되도록 함