### PR TITLE
MP-222 🐛 Fix: Generated 패키지에 속하는 매퍼 클래스를 직접 의존하는 문제 수정

### DIFF
--- a/src/main/java/kr/modusplant/legacy/domains/communication/app/service/CommCommentApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/communication/app/service/CommCommentApplicationService.java
@@ -11,7 +11,6 @@ import kr.modusplant.legacy.domains.communication.app.http.response.CommCommentR
 import kr.modusplant.legacy.domains.communication.domain.service.CommCommentValidationService;
 import kr.modusplant.legacy.domains.communication.domain.service.CommPostValidationService;
 import kr.modusplant.legacy.domains.communication.mapper.CommCommentAppInfraMapper;
-import kr.modusplant.legacy.domains.communication.mapper.CommCommentAppInfraMapperImpl;
 import kr.modusplant.legacy.domains.member.domain.service.SiteMemberValidationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
@@ -31,7 +30,7 @@ public class CommCommentApplicationService {
     private final CommCommentValidationService commCommentValidationService;
     private final CommPostValidationService commPostValidationService;
     private final SiteMemberValidationService memberValidationService;
-    private final CommCommentAppInfraMapper commCommentAppInfraMapper = new CommCommentAppInfraMapperImpl();
+    private final CommCommentAppInfraMapper commCommentAppInfraMapper;
     private final CommCommentRepository commCommentRepository;
     private final CommPostRepository commPostRepository;
     private final SiteMemberRepository memberRepository;

--- a/src/main/java/kr/modusplant/legacy/domains/communication/app/service/CommPostApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/communication/app/service/CommPostApplicationService.java
@@ -16,7 +16,6 @@ import kr.modusplant.legacy.domains.communication.app.http.response.CommPostResp
 import kr.modusplant.legacy.domains.communication.domain.service.CommCategoryValidationService;
 import kr.modusplant.legacy.domains.communication.domain.service.CommPostValidationService;
 import kr.modusplant.legacy.domains.communication.mapper.CommPostAppInfraMapper;
-import kr.modusplant.legacy.domains.communication.mapper.CommPostAppInfraMapperImpl;
 import kr.modusplant.legacy.domains.communication.persistence.repository.CommPostViewCountRedisRepository;
 import kr.modusplant.legacy.domains.communication.persistence.repository.CommPostViewLockRedisRepository;
 import kr.modusplant.legacy.domains.member.domain.service.SiteMemberValidationService;
@@ -48,7 +47,7 @@ public class CommPostApplicationService {
     private final CommSecondaryCategoryRepository commSecondaryCategoryRepository;
     private final CommPostViewCountRedisRepository commPostViewCountRedisRepository;
     private final CommPostViewLockRedisRepository commPostViewLockRedisRepository;
-    private final CommPostAppInfraMapper commPostAppInfraMapper = new CommPostAppInfraMapperImpl();
+    private final CommPostAppInfraMapper commPostAppInfraMapper;
 
     @Value("${redis.ttl.view_count}")
     private long ttlMinutes;

--- a/src/main/java/kr/modusplant/legacy/domains/communication/app/service/CommPrimaryCategoryApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/communication/app/service/CommPrimaryCategoryApplicationService.java
@@ -6,7 +6,6 @@ import kr.modusplant.legacy.domains.communication.app.http.request.CommCategoryI
 import kr.modusplant.legacy.domains.communication.app.http.response.CommCategoryResponse;
 import kr.modusplant.legacy.domains.communication.domain.service.CommCategoryValidationService;
 import kr.modusplant.legacy.domains.communication.mapper.CommPrimaryCategoryAppInfraMapper;
-import kr.modusplant.legacy.domains.communication.mapper.CommPrimaryCategoryAppInfraMapperImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -26,7 +25,7 @@ public class CommPrimaryCategoryApplicationService {
 
     private final CommCategoryValidationService validationService;
     private final CommPrimaryCategoryRepository commCategoryRepository;
-    private final CommPrimaryCategoryAppInfraMapper commCategoryAppInfraMapper = new CommPrimaryCategoryAppInfraMapperImpl();
+    private final CommPrimaryCategoryAppInfraMapper commCategoryAppInfraMapper;
 
     @Cacheable(value = "comm_categories")
     public List<CommCategoryResponse> getAll() {

--- a/src/main/java/kr/modusplant/legacy/domains/communication/app/service/CommSecondaryCategoryApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/communication/app/service/CommSecondaryCategoryApplicationService.java
@@ -6,7 +6,6 @@ import kr.modusplant.legacy.domains.communication.app.http.request.CommCategoryI
 import kr.modusplant.legacy.domains.communication.app.http.response.CommCategoryResponse;
 import kr.modusplant.legacy.domains.communication.domain.service.CommCategoryValidationService;
 import kr.modusplant.legacy.domains.communication.mapper.CommSecondaryCategoryAppInfraMapper;
-import kr.modusplant.legacy.domains.communication.mapper.CommSecondaryCategoryAppInfraMapperImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -26,7 +25,7 @@ public class CommSecondaryCategoryApplicationService {
 
     private final CommCategoryValidationService validationService;
     private final CommSecondaryCategoryRepository commCategoryRepository;
-    private final CommSecondaryCategoryAppInfraMapper commCategoryAppInfraMapper = new CommSecondaryCategoryAppInfraMapperImpl();
+    private final CommSecondaryCategoryAppInfraMapper commCategoryAppInfraMapper;
 
     @Cacheable(value = "comm_categories")
     public List<CommCategoryResponse> getAll() {

--- a/src/main/java/kr/modusplant/legacy/domains/member/app/service/SiteMemberApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/member/app/service/SiteMemberApplicationService.java
@@ -8,7 +8,6 @@ import kr.modusplant.legacy.domains.member.app.http.request.SiteMemberUpdateRequ
 import kr.modusplant.legacy.domains.member.app.http.response.SiteMemberResponse;
 import kr.modusplant.legacy.domains.member.domain.service.SiteMemberValidationService;
 import kr.modusplant.legacy.domains.member.mapper.SiteMemberAppInfraMapper;
-import kr.modusplant.legacy.domains.member.mapper.SiteMemberAppInfraMapperImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -28,7 +27,7 @@ public class SiteMemberApplicationService implements UuidCrudApplicationService<
 
     private final SiteMemberValidationService validationService;
     private final SiteMemberRepository memberRepository;
-    private final SiteMemberAppInfraMapper memberAppInfraMapper = new SiteMemberAppInfraMapperImpl();
+    private final SiteMemberAppInfraMapper memberAppInfraMapper;
 
     @Override
     public List<SiteMemberResponse> getAll() {

--- a/src/main/java/kr/modusplant/legacy/domains/member/app/service/SiteMemberAuthApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/member/app/service/SiteMemberAuthApplicationService.java
@@ -12,7 +12,6 @@ import kr.modusplant.legacy.domains.member.domain.service.SiteMemberAuthValidati
 import kr.modusplant.legacy.domains.member.domain.service.SiteMemberValidationService;
 import kr.modusplant.legacy.domains.member.enums.AuthProvider;
 import kr.modusplant.legacy.domains.member.mapper.SiteMemberAuthAppInfraMapper;
-import kr.modusplant.legacy.domains.member.mapper.SiteMemberAuthAppInfraMapperImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -32,7 +31,7 @@ public class SiteMemberAuthApplicationService implements UuidCrudApplicationServ
     private final SiteMemberAuthValidationService memberAuthValidationService;
     private final SiteMemberAuthRepository memberAuthRepository;
     private final SiteMemberRepository memberRepository;
-    private final SiteMemberAuthAppInfraMapper memberAuthAppInfraMapper = new SiteMemberAuthAppInfraMapperImpl();
+    private final SiteMemberAuthAppInfraMapper memberAuthAppInfraMapper;
 
     @Override
     public List<SiteMemberAuthResponse> getAll() {

--- a/src/main/java/kr/modusplant/legacy/domains/member/app/service/SiteMemberRoleApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/member/app/service/SiteMemberRoleApplicationService.java
@@ -11,7 +11,6 @@ import kr.modusplant.legacy.domains.member.app.http.response.SiteMemberRoleRespo
 import kr.modusplant.legacy.domains.member.domain.service.SiteMemberRoleValidationService;
 import kr.modusplant.legacy.domains.member.domain.service.SiteMemberValidationService;
 import kr.modusplant.legacy.domains.member.mapper.SiteMemberRoleAppInfraMapper;
-import kr.modusplant.legacy.domains.member.mapper.SiteMemberRoleAppInfraMapperImpl;
 import kr.modusplant.legacy.modules.security.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
@@ -32,7 +31,7 @@ public class SiteMemberRoleApplicationService implements UuidCrudApplicationServ
     private final SiteMemberRoleValidationService memberRoleValidationService;
     private final SiteMemberRoleRepository memberRoleRepository;
     private final SiteMemberRepository memberRepository;
-    private final SiteMemberRoleAppInfraMapper memberRoleEntityMapper = new SiteMemberRoleAppInfraMapperImpl();
+    private final SiteMemberRoleAppInfraMapper memberRoleEntityMapper;
 
     @Override
     public List<SiteMemberRoleResponse> getAll() {

--- a/src/main/java/kr/modusplant/legacy/domains/member/app/service/SiteMemberTermApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/member/app/service/SiteMemberTermApplicationService.java
@@ -11,7 +11,6 @@ import kr.modusplant.legacy.domains.member.app.http.response.SiteMemberTermRespo
 import kr.modusplant.legacy.domains.member.domain.service.SiteMemberTermValidationService;
 import kr.modusplant.legacy.domains.member.domain.service.SiteMemberValidationService;
 import kr.modusplant.legacy.domains.member.mapper.SiteMemberTermAppInfraMapper;
-import kr.modusplant.legacy.domains.member.mapper.SiteMemberTermAppInfraMapperImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -31,7 +30,7 @@ public class SiteMemberTermApplicationService implements UuidCrudApplicationServ
     private final SiteMemberValidationService memberValidationService;
     private final SiteMemberTermRepository memberTermRepository;
     private final SiteMemberRepository memberRepository;
-    private final SiteMemberTermAppInfraMapper memberTermAppInfraMapper = new SiteMemberTermAppInfraMapperImpl();
+    private final SiteMemberTermAppInfraMapper memberTermAppInfraMapper;
 
     @Override
     public List<SiteMemberTermResponse> getAll() {

--- a/src/main/java/kr/modusplant/legacy/domains/term/app/service/TermApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/domains/term/app/service/TermApplicationService.java
@@ -7,7 +7,6 @@ import kr.modusplant.legacy.domains.term.app.http.request.TermUpdateRequest;
 import kr.modusplant.legacy.domains.term.app.http.response.TermResponse;
 import kr.modusplant.legacy.domains.term.domain.service.TermValidationService;
 import kr.modusplant.legacy.domains.term.mapper.TermAppInfraMapper;
-import kr.modusplant.legacy.domains.term.mapper.TermAppInfraMapperImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -27,7 +26,7 @@ public class TermApplicationService {
 
     private final TermValidationService validationService;
     private final TermRepository termRepository;
-    private final TermAppInfraMapper termAppInfraMapper = new TermAppInfraMapperImpl();
+    private final TermAppInfraMapper termAppInfraMapper;
 
     @Cacheable(value = "terms")
     public List<TermResponse> getAll() {

--- a/src/main/java/kr/modusplant/legacy/modules/auth/social/app/service/SocialAuthApplicationService.java
+++ b/src/main/java/kr/modusplant/legacy/modules/auth/social/app/service/SocialAuthApplicationService.java
@@ -10,7 +10,6 @@ import kr.modusplant.framework.out.persistence.jpa.repository.SiteMemberRoleRepo
 import kr.modusplant.legacy.domains.member.domain.model.SiteMemberAuth;
 import kr.modusplant.legacy.domains.member.enums.AuthProvider;
 import kr.modusplant.legacy.domains.member.mapper.SiteMemberAuthDomainInfraMapper;
-import kr.modusplant.legacy.domains.member.mapper.SiteMemberAuthDomainInfraMapperImpl;
 import kr.modusplant.legacy.modules.auth.social.app.dto.JwtUserPayload;
 import kr.modusplant.legacy.modules.auth.social.app.dto.supers.SocialUserInfo;
 import kr.modusplant.legacy.modules.auth.social.app.service.supers.SocialAuthClient;
@@ -34,7 +33,7 @@ public class SocialAuthApplicationService {
     private final SiteMemberRepository memberRepository;
     private final SiteMemberAuthRepository memberAuthRepository;
     private final SiteMemberRoleRepository memberRoleRepository;
-    private final SiteMemberAuthDomainInfraMapper memberAuthEntityMapper = new SiteMemberAuthDomainInfraMapperImpl();
+    private final SiteMemberAuthDomainInfraMapper memberAuthEntityMapper;
 
     public JwtUserPayload handleSocialLogin(AuthProvider provider, String code) {
         // 소셜 토큰 발급

--- a/src/test/java/kr/modusplant/legacy/domains/communication/app/service/CommPostApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/legacy/domains/communication/app/service/CommPostApplicationServiceTest.java
@@ -21,6 +21,7 @@ import kr.modusplant.legacy.domains.communication.common.util.entity.CommPrimary
 import kr.modusplant.legacy.domains.communication.common.util.entity.CommSecondaryCategoryEntityTestUtils;
 import kr.modusplant.legacy.domains.communication.domain.service.CommCategoryValidationService;
 import kr.modusplant.legacy.domains.communication.domain.service.CommPostValidationService;
+import kr.modusplant.legacy.domains.communication.mapper.CommPostAppInfraMapper;
 import kr.modusplant.legacy.domains.communication.persistence.repository.CommPostViewCountRedisRepository;
 import kr.modusplant.legacy.domains.communication.persistence.repository.CommPostViewLockRedisRepository;
 import kr.modusplant.legacy.domains.member.common.util.entity.SiteMemberEntityTestUtils;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static kr.modusplant.framework.out.persistence.jpa.entity.CommPostEntity.CommPostEntityBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -72,6 +74,8 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
     private CommPostViewCountRedisRepository commPostViewCountRedisRepository;
     @Mock
     private CommPostViewLockRedisRepository commPostViewLockRedisRepository;
+    @Mock
+    private CommPostAppInfraMapper commPostAppInfraMapper;
     @InjectMocks
     private CommPostApplicationService commPostApplicationService;
 
@@ -81,7 +85,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
     private SiteMemberEntity siteMemberEntity;
     private CommPrimaryCategoryEntity commPrimaryCategoryEntity;
     private CommSecondaryCategoryEntity commSecondaryCategoryEntity;
-    private CommPostEntity.CommPostEntityBuilder commPostEntityBuilder;
+    private CommPostEntityBuilder commPostEntityBuilder;
 
     @BeforeEach
     void setUp() {
@@ -109,6 +113,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
 
         given(commPostRepository.findByIsDeletedFalseOrderByCreatedAtDesc(pageable)).willReturn(page);
         given(multipartDataProcessor.convertFileSrcToBinaryData(any(JsonNode.class))).willReturn(mock(ArrayNode.class));
+        given(commPostAppInfraMapper.toCommPostResponse(any())).willReturn(mock(CommPostResponse.class));
 
         // when
         Page<CommPostResponse> result = commPostApplicationService.getAll(pageable);
@@ -137,6 +142,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         given(siteMemberRepository.findByUuid(memberUuid)).willReturn(Optional.of(siteMemberEntity));
         given(commPostRepository.findByAuthMemberAndIsDeletedFalseOrderByCreatedAtDesc(siteMemberEntity, pageable)).willReturn(page);
         given(multipartDataProcessor.convertFileSrcToBinaryData(any(JsonNode.class))).willReturn(mock(ArrayNode.class));
+        given(commPostAppInfraMapper.toCommPostResponse(any())).willReturn(mock(CommPostResponse.class));
 
         // when
         Page<CommPostResponse> result = commPostApplicationService.getByMemberUuid(memberUuid, pageable);
@@ -166,6 +172,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         given(commPrimaryCategoryRepository.findByUuid(commPrimaryCategoryEntity.getUuid())).willReturn(Optional.of(commPrimaryCategoryEntity));
         given(commPostRepository.findByPrimaryCategoryAndIsDeletedFalseOrderByCreatedAtDesc(commPrimaryCategoryEntity, pageable)).willReturn(page);
         given(multipartDataProcessor.convertFileSrcToBinaryData(any(JsonNode.class))).willReturn(mock(ArrayNode.class));
+        given(commPostAppInfraMapper.toCommPostResponse(any())).willReturn(mock(CommPostResponse.class));
 
         // when
         Page<CommPostResponse> result = commPostApplicationService.getByPrimaryCategoryUuid(commPrimaryCategoryEntity.getUuid(), pageable);
@@ -194,6 +201,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         given(commSecondaryCategoryRepository.findByUuid(commSecondaryCategoryEntity.getUuid())).willReturn(Optional.of(commSecondaryCategoryEntity));
         given(commPostRepository.findBySecondaryCategoryAndIsDeletedFalseOrderByCreatedAtDesc(commSecondaryCategoryEntity, pageable)).willReturn(page);
         given(multipartDataProcessor.convertFileSrcToBinaryData(any(JsonNode.class))).willReturn(mock(ArrayNode.class));
+        given(commPostAppInfraMapper.toCommPostResponse(any())).willReturn(mock(CommPostResponse.class));
 
         // when
         Page<CommPostResponse> result = commPostApplicationService.getBySecondaryCategoryUuid(commSecondaryCategoryEntity.getUuid(), pageable);
@@ -222,6 +230,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
 
         given(commPostRepository.searchByTitleOrContent(keyword,pageable)).willReturn(page);
         given(multipartDataProcessor.convertFileSrcToBinaryData(any(JsonNode.class))).willReturn(mock(ArrayNode.class));
+        given(commPostAppInfraMapper.toCommPostResponse(any())).willReturn(mock(CommPostResponse.class));
 
         // when
         Page<CommPostResponse> result = commPostApplicationService.searchByKeyword(keyword, pageable);
@@ -247,6 +256,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         given(commPostRepository.findByUlid(post.getUlid())).willReturn(Optional.of(post));
         given(multipartDataProcessor.convertFileSrcToBinaryData(any(JsonNode.class))).willReturn(mock(ArrayNode.class));
         given(commPostViewCountRedisRepository.read(anyString())).willReturn(56L);
+        given(commPostAppInfraMapper.toCommPostResponse(any())).willReturn(mock(CommPostResponse.class));
 
         // when
         Optional<CommPostResponse> result = commPostApplicationService.getByUlid(post.getUlid());

--- a/src/test/java/kr/modusplant/legacy/domains/communication/app/service/CommPostApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/legacy/domains/communication/app/service/CommPostApplicationServiceTest.java
@@ -43,6 +43,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -125,7 +126,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         assertThat(result.getSize()).isEqualTo(2);
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getTotalPages()).isEqualTo(2);
-        assertThat(result.getContent()).allMatch(r -> r instanceof CommPostResponse);
+        assertThat(result.getContent()).allMatch(Objects::nonNull);
         then(commPostRepository).should().findByIsDeletedFalseOrderByCreatedAtDesc(pageable);
         then(multipartDataProcessor).should(times(2)).convertFileSrcToBinaryData(any(JsonNode.class));
     }
@@ -154,7 +155,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         assertThat(result.getSize()).isEqualTo(2);
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getTotalPages()).isEqualTo(2);
-        assertThat(result.getContent()).allMatch(r -> r instanceof CommPostResponse);
+        assertThat(result.getContent()).allMatch(Objects::nonNull);
         then(siteMemberRepository).should().findByUuid(memberUuid);
         then(commPostRepository).should().findByAuthMemberAndIsDeletedFalseOrderByCreatedAtDesc(siteMemberEntity, pageable);
         then(multipartDataProcessor).should(times(2)).convertFileSrcToBinaryData(any(JsonNode.class));
@@ -183,7 +184,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         assertThat(result.getNumber()).isEqualTo(0);
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getTotalPages()).isEqualTo(2);
-        assertThat(result.getContent()).allMatch(r -> r instanceof CommPostResponse);
+        assertThat(result.getContent()).allMatch(Objects::nonNull);
         then(commPrimaryCategoryRepository).should().findByUuid(commPrimaryCategoryEntity.getUuid());
         then(commPostRepository).should().findByPrimaryCategoryAndIsDeletedFalseOrderByCreatedAtDesc(commPrimaryCategoryEntity, pageable);
         then(multipartDataProcessor).should(times(2)).convertFileSrcToBinaryData(any(JsonNode.class));
@@ -212,7 +213,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         assertThat(result.getNumber()).isEqualTo(0);
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getTotalPages()).isEqualTo(2);
-        assertThat(result.getContent()).allMatch(r -> r instanceof CommPostResponse);
+        assertThat(result.getContent()).allMatch(Objects::nonNull);
         then(commSecondaryCategoryRepository).should().findByUuid(commSecondaryCategoryEntity.getUuid());
         then(commPostRepository).should().findBySecondaryCategoryAndIsDeletedFalseOrderByCreatedAtDesc(commSecondaryCategoryEntity, pageable);
         then(multipartDataProcessor).should(times(2)).convertFileSrcToBinaryData(any(JsonNode.class));
@@ -242,7 +243,7 @@ class CommPostApplicationServiceTest implements SiteMemberEntityTestUtils, CommP
         assertThat(result.getSize()).isEqualTo(2);
         assertThat(result.getTotalElements()).isEqualTo(2);
         assertThat(result.getTotalPages()).isEqualTo(1);
-        assertThat(result.getContent()).allMatch(r -> r instanceof CommPostResponse);
+        assertThat(result.getContent()).allMatch(Objects::nonNull);
         then(commPostRepository).should().searchByTitleOrContent(keyword,pageable);
         then(multipartDataProcessor).should(times(2)).convertFileSrcToBinaryData(any(JsonNode.class));
     }

--- a/src/test/java/kr/modusplant/legacy/domains/communication/app/service/CommPrimaryCategoryApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/legacy/domains/communication/app/service/CommPrimaryCategoryApplicationServiceTest.java
@@ -7,7 +7,6 @@ import kr.modusplant.legacy.domains.communication.common.util.app.http.request.C
 import kr.modusplant.legacy.domains.communication.common.util.app.http.response.CommCategoryResponseTestUtils;
 import kr.modusplant.legacy.domains.communication.common.util.entity.CommPrimaryCategoryEntityTestUtils;
 import kr.modusplant.legacy.domains.communication.mapper.CommPrimaryCategoryAppInfraMapper;
-import kr.modusplant.legacy.domains.communication.mapper.CommPrimaryCategoryAppInfraMapperImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,12 +24,13 @@ class CommPrimaryCategoryApplicationServiceTest implements CommCategoryRequestTe
 
     private final CommPrimaryCategoryApplicationService commCategoryApplicationService;
     private final CommPrimaryCategoryRepository commCategoryRepository;
-    private final CommPrimaryCategoryAppInfraMapper commCategoryAppInfraMapper = new CommPrimaryCategoryAppInfraMapperImpl();
+    private final CommPrimaryCategoryAppInfraMapper commCategoryAppInfraMapper;
 
     @Autowired
-    CommPrimaryCategoryApplicationServiceTest(CommPrimaryCategoryApplicationService commCategoryApplicationService, CommPrimaryCategoryRepository commCategoryRepository) {
+    CommPrimaryCategoryApplicationServiceTest(CommPrimaryCategoryApplicationService commCategoryApplicationService, CommPrimaryCategoryRepository commCategoryRepository, CommPrimaryCategoryAppInfraMapper commCategoryAppInfraMapper) {
         this.commCategoryApplicationService = commCategoryApplicationService;
         this.commCategoryRepository = commCategoryRepository;
+        this.commCategoryAppInfraMapper = commCategoryAppInfraMapper;
     }
 
     @DisplayName("모든 컨텐츠 1차 항목 얻기")

--- a/src/test/java/kr/modusplant/legacy/domains/communication/app/service/CommSecondaryCategoryApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/legacy/domains/communication/app/service/CommSecondaryCategoryApplicationServiceTest.java
@@ -7,7 +7,6 @@ import kr.modusplant.legacy.domains.communication.common.util.app.http.request.C
 import kr.modusplant.legacy.domains.communication.common.util.app.http.response.CommCategoryResponseTestUtils;
 import kr.modusplant.legacy.domains.communication.common.util.entity.CommSecondaryCategoryEntityTestUtils;
 import kr.modusplant.legacy.domains.communication.mapper.CommSecondaryCategoryAppInfraMapper;
-import kr.modusplant.legacy.domains.communication.mapper.CommSecondaryCategoryAppInfraMapperImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,12 +24,13 @@ class CommSecondaryCategoryApplicationServiceTest implements CommCategoryRequest
 
     private final CommSecondaryCategoryApplicationService commCategoryApplicationService;
     private final CommSecondaryCategoryRepository commCategoryRepository;
-    private final CommSecondaryCategoryAppInfraMapper commCategoryAppInfraMapper = new CommSecondaryCategoryAppInfraMapperImpl();
+    private final CommSecondaryCategoryAppInfraMapper commCategoryAppInfraMapper;
 
     @Autowired
-    CommSecondaryCategoryApplicationServiceTest(CommSecondaryCategoryApplicationService commCategoryApplicationService, CommSecondaryCategoryRepository commCategoryRepository) {
+    CommSecondaryCategoryApplicationServiceTest(CommSecondaryCategoryApplicationService commCategoryApplicationService, CommSecondaryCategoryRepository commCategoryRepository, CommSecondaryCategoryAppInfraMapper commCategoryAppInfraMapper) {
         this.commCategoryApplicationService = commCategoryApplicationService;
         this.commCategoryRepository = commCategoryRepository;
+        this.commCategoryAppInfraMapper = commCategoryAppInfraMapper;
     }
 
     @DisplayName("모든 컨텐츠 2차 항목 얻기")

--- a/src/test/java/kr/modusplant/legacy/domains/term/app/service/TermApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/legacy/domains/term/app/service/TermApplicationServiceTest.java
@@ -8,7 +8,6 @@ import kr.modusplant.legacy.domains.term.common.util.app.http.request.TermReques
 import kr.modusplant.legacy.domains.term.common.util.app.http.response.TermResponseTestUtils;
 import kr.modusplant.legacy.domains.term.common.util.entity.TermEntityTestUtils;
 import kr.modusplant.legacy.domains.term.mapper.TermAppInfraMapper;
-import kr.modusplant.legacy.domains.term.mapper.TermAppInfraMapperImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,12 +25,13 @@ class TermApplicationServiceTest implements TermRequestTestUtils, TermResponseTe
 
     private final TermApplicationService termApplicationService;
     private final TermRepository termRepository;
-    private final TermAppInfraMapper termAppInfraMapper = new TermAppInfraMapperImpl();
+    private final TermAppInfraMapper termAppInfraMapper;
 
     @Autowired
-    TermApplicationServiceTest(TermApplicationService termApplicationService, TermRepository termRepository) {
+    TermApplicationServiceTest(TermApplicationService termApplicationService, TermRepository termRepository, TermAppInfraMapper termAppInfraMapper) {
         this.termApplicationService = termApplicationService;
         this.termRepository = termRepository;
+        this.termAppInfraMapper = termAppInfraMapper;
     }
 
     @DisplayName("uuid로 약관 얻기")

--- a/src/test/java/kr/modusplant/legacy/modules/auth/social/app/service/SocialAuthApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/legacy/modules/auth/social/app/service/SocialAuthApplicationServiceTest.java
@@ -7,11 +7,12 @@ import kr.modusplant.framework.out.persistence.jpa.repository.SiteMemberAuthRepo
 import kr.modusplant.framework.out.persistence.jpa.repository.SiteMemberRepository;
 import kr.modusplant.framework.out.persistence.jpa.repository.SiteMemberRoleRepository;
 import kr.modusplant.legacy.domains.common.context.DomainsServiceOnlyContext;
+import kr.modusplant.legacy.domains.member.common.util.domain.SiteMemberAuthTestUtils;
 import kr.modusplant.legacy.domains.member.common.util.entity.SiteMemberAuthEntityTestUtils;
 import kr.modusplant.legacy.domains.member.common.util.entity.SiteMemberEntityTestUtils;
+import kr.modusplant.legacy.domains.member.domain.model.SiteMemberAuth;
 import kr.modusplant.legacy.domains.member.enums.AuthProvider;
 import kr.modusplant.legacy.domains.member.mapper.SiteMemberAuthDomainInfraMapper;
-import kr.modusplant.legacy.domains.member.mapper.SiteMemberAuthDomainInfraMapperImpl;
 import kr.modusplant.legacy.modules.auth.social.app.dto.GoogleUserInfo;
 import kr.modusplant.legacy.modules.auth.social.app.dto.JwtUserPayload;
 import kr.modusplant.legacy.modules.auth.social.app.dto.KakaoUserInfo;
@@ -36,7 +37,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @DomainsServiceOnlyContext
-class SocialAuthApplicationServiceTest implements SiteMemberEntityTestUtils, SiteMemberAuthEntityTestUtils {
+class SocialAuthApplicationServiceTest implements SiteMemberAuthTestUtils, SiteMemberEntityTestUtils, SiteMemberAuthEntityTestUtils {
 
     private SocialAuthApplicationService socialAuthApplicationService;
     @Mock
@@ -49,8 +50,8 @@ class SocialAuthApplicationServiceTest implements SiteMemberEntityTestUtils, Sit
     private SiteMemberAuthRepository memberAuthRepository;
     @Mock
     private SiteMemberRoleRepository memberRoleRepository;
-
-    private final SiteMemberAuthDomainInfraMapper memberAuthEntityMapper = new SiteMemberAuthDomainInfraMapperImpl();
+    @Mock
+    private SiteMemberAuthDomainInfraMapper memberAuthEntityMapper;
 
     private final String code = "sample-code";
     private final AuthProvider provider = AuthProvider.GOOGLE;
@@ -135,7 +136,8 @@ class SocialAuthApplicationServiceTest implements SiteMemberEntityTestUtils, Sit
                 .member(memberEntity)
                 .role(Role.USER).build();
 
-        given(memberAuthRepository.findByProviderAndProviderId(provider,id)).willReturn(Optional.of(memberAuthEntity));
+        given(memberAuthRepository.findByProviderAndProviderId(provider, id)).willReturn(Optional.of(memberAuthEntity));
+        given(memberAuthEntityMapper.toSiteMemberAuth(memberAuthEntity)).willReturn(SiteMemberAuth.builder().memberAuth(memberAuthBasicUserWithUuid).activeMemberUuid(memberEntity.getUuid()).build());
         given(memberRepository.findByUuid(memberEntity.getUuid())).willReturn(Optional.of(memberEntity));
         given(memberRepository.save(any())).willReturn(memberEntity);
         given(memberRoleRepository.findByMember(memberEntity)).willReturn(Optional.of(memberRoleEntity));

--- a/src/test/java/kr/modusplant/legacy/modules/auth/social/app/service/SocialAuthApplicationServiceTest.java
+++ b/src/test/java/kr/modusplant/legacy/modules/auth/social/app/service/SocialAuthApplicationServiceTest.java
@@ -62,7 +62,7 @@ class SocialAuthApplicationServiceTest implements SiteMemberEntityTestUtils, Sit
     void setUp() {
         socialAuthApplicationService = spy(new SocialAuthApplicationService(
                 kakaoAuthClient, googleAuthClient,
-                memberRepository, memberAuthRepository, memberRoleRepository
+                memberRepository, memberAuthRepository, memberRoleRepository, memberAuthEntityMapper
                 )
         );
     }


### PR DESCRIPTION
- src.main.java에 있는, MapStruct가 만들어낸 매퍼 클래스에 직접 의존하는 모든 코드를 인터페이스에 의존하는 코드로 수정
- 이렇게 해도 componentModel = spring으로 설정되어 있어 DI의 이점을 활용할 수 있음
- src.test에 있는 클래스에서도 동일한 작업을 수행했으나, 단위 테스트의 경우 Spring Boot의 자동 구성의 이점을 누릴 수 없는 경우가 있으며, 그런 경우에만 어쩔 수 없이 매퍼 클래스에 대한 직접적인 의존성을 유지