### PR TITLE
♻️ Refactor: 관리자 전용 API 로컬 환경 테스트 완료

### DIFF
--- a/src/main/java/kr/modusplant/domains/comment/framework/inbound/web/rest/CommentRestController.java
+++ b/src/main/java/kr/modusplant/domains/comment/framework/inbound/web/rest/CommentRestController.java
@@ -3,6 +3,7 @@ package kr.modusplant.domains.comment.framework.inbound.web.rest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -142,7 +143,8 @@ public class CommentRestController {
 
     @Operation(
             summary = "컨텐츠 댓글 삽입 API",
-            description = "게시글 식별자와 경로, 회원 식별자, 컨텐츠 정보로 컨텐츠 항목을 삽입합니다."
+            description = "게시글 식별자와 경로, 회원 식별자, 컨텐츠 정보로 컨텐츠 항목을 삽입합니다.",
+            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
     @PostMapping
     public ResponseEntity<DataResponse<Void>> register(
@@ -157,7 +159,8 @@ public class CommentRestController {
 
     @Operation(
             summary = "컨텐츠 댓글 수정 API",
-            description = "게시글 식별자, 댓글 경로, 댓글 내용으로 댓글을 갱신합니다."
+            description = "게시글 식별자, 댓글 경로, 댓글 내용으로 댓글을 갱신합니다.",
+            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
     @PutMapping("/update")
     public ResponseEntity<DataResponse<Void>> update(
@@ -169,7 +172,8 @@ public class CommentRestController {
 
     @Operation(
             summary = "식별자로 컨텐츠 댓글 제거 API",
-            description = "식별자로 컨텐츠 댓글을 제거합니다."
+            description = "식별자로 컨텐츠 댓글을 제거합니다.",
+            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
     @DeleteMapping("/post/{ulid}/path/{path}")
     public ResponseEntity<DataResponse<Void>> delete(

--- a/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberAdminController.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberAdminController.java
@@ -2,7 +2,9 @@ package kr.modusplant.domains.member.adapter.controller;
 
 import kr.modusplant.domains.member.adapter.helper.MemberValidationHelper;
 import kr.modusplant.domains.member.domain.event.CommentAbuseReportApproveEvent;
+import kr.modusplant.domains.member.domain.event.CommentAbuseReportDismissEvent;
 import kr.modusplant.domains.member.domain.event.PostAbuseReportApproveEvent;
+import kr.modusplant.domains.member.domain.event.PostAbuseReportDismissEvent;
 import kr.modusplant.domains.member.domain.vo.*;
 import kr.modusplant.domains.member.usecase.model.read.CommentAbuseReportDashboardReadModel;
 import kr.modusplant.domains.member.usecase.model.read.PostAbuseReportDashboardReadModel;
@@ -118,6 +120,7 @@ public class MemberAdminController {
         if (reportDashboardRepository.isDismissedInPostAbuseReportDashboard(postId)) {
             throw new ExistsValueException(EXISTS_POST_ABUSE_REPORT_DISMISSED, "status");
         }
+        applicationEventPublisher.publishEvent(PostAbuseReportDismissEvent.create(postId.getValue()));
         return reportDashboardRepository.dismissPostAbuseReport(postId);
     }
 
@@ -174,6 +177,8 @@ public class MemberAdminController {
         if (reportDashboardRepository.isDismissedInCommentAbuseReportDashboard(commentId)) {
             throw new ExistsValueException(EXISTS_COMMENT_ABUSE_REPORT_DISMISSED, "status");
         }
+        applicationEventPublisher.publishEvent(
+                CommentAbuseReportDismissEvent.create(postId.getValue(), commentPath.getValue()));
         return reportDashboardRepository.dismissCommentAbuseReport(commentId);
     }
 
@@ -185,7 +190,8 @@ public class MemberAdminController {
         if (reportDashboardRepository.isApprovedInCommentAbuseReportDashboard(commentId)) {
             throw new ExistsValueException(EXISTS_COMMENT_ABUSE_REPORT_BLINDED, "status");
         }
-        applicationEventPublisher.publishEvent(CommentAbuseReportApproveEvent.create(postId.getValue(), commentPath.getValue()));
+        applicationEventPublisher.publishEvent(
+                CommentAbuseReportApproveEvent.create(postId.getValue(), commentPath.getValue()));
         return reportDashboardRepository.approveCommentAbuseReport(commentId);
     }
 }

--- a/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberAdminController.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberAdminController.java
@@ -10,6 +10,9 @@ import kr.modusplant.domains.member.usecase.model.read.ProposalOrBugReportDashbo
 import kr.modusplant.domains.member.usecase.port.repository.ReportDashboardRepository;
 import kr.modusplant.domains.member.usecase.port.repository.ReportRepository;
 import kr.modusplant.domains.member.usecase.record.*;
+import kr.modusplant.domains.member.usecase.response.CommentAbuseReportDashboardResponse;
+import kr.modusplant.domains.member.usecase.response.PostAbuseReportDashboardResponse;
+import kr.modusplant.domains.member.usecase.response.ProposalOrBugReportDashboardResponse;
 import kr.modusplant.shared.exception.ExistsValueException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,13 +35,27 @@ public class MemberAdminController {
     private final ReportDashboardRepository reportDashboardRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    public List<ProposalOrBugReportDashboardReadModel> getProposalOrBug(ProposalOrBugReportGetRecord record) {
-        if (record.lastReportUlid() != null) {
+    public ProposalOrBugReportDashboardResponse getProposalOrBug(ProposalOrBugReportGetRecord record) {
+        int reportPageSize = record.size() + 1;
+        List<ProposalOrBugReportDashboardReadModel> readModels;
+        if (record.lastReportUlid() != null) { // 특정 lastReportId 이후부터 조회
             ReportId reportId = ReportId.create(record.lastReportUlid());
             memberValidationHelper.validateIfReportExists(reportId);
-            return reportDashboardRepository.getProposalOrBugReports(ReportPageSize.create(record.size()), record.status(), reportId);
-        } else {
-            return reportDashboardRepository.getProposalOrBugReports(ReportPageSize.create(record.size()), record.status(), null);
+            readModels = reportDashboardRepository.getProposalOrBugReports(
+                    ReportPageSize.create(reportPageSize), record.status(), reportId);
+        } else { // 첫 보고서 데이터부터 조회
+            readModels = reportDashboardRepository.getProposalOrBugReports(
+                    ReportPageSize.create(reportPageSize), record.status(), null);
+        }
+
+        if (readModels.size() == reportPageSize) { // hasNext == true
+            List<ProposalOrBugReportDashboardReadModel> returnedReadModels =
+                    readModels.subList(0, reportPageSize - 1);
+            return ProposalOrBugReportDashboardResponse.of(
+                    returnedReadModels, returnedReadModels.getLast().ulid(), true);
+        } else { // hasNext == false
+            return ProposalOrBugReportDashboardResponse.of(
+                    readModels, readModels.getLast().ulid(), false);
         }
     }
 
@@ -58,15 +75,27 @@ public class MemberAdminController {
         }
     }
 
-    public List<PostAbuseReportDashboardReadModel> getPostAbuseReport(PostAbuseReportGetRecord record) {
+    public PostAbuseReportDashboardResponse getPostAbuseReport(PostAbuseReportGetRecord record) {
+        int reportPageSize = record.size() + 1;
+        List<PostAbuseReportDashboardReadModel> readModels;
         if (record.lastPostUlid() != null) {
             ActivitySubjectPostId activitySubjectPostId = ActivitySubjectPostId.create(record.lastPostUlid());
             memberValidationHelper.validateIfActivitySubjectPostExists(activitySubjectPostId);
-            return reportDashboardRepository.getPostAbuseReports(
-                    ReportPageSize.create(record.size()), record.status(), activitySubjectPostId);
+            readModels = reportDashboardRepository.getPostAbuseReports(
+                    ReportPageSize.create(reportPageSize), record.status(), activitySubjectPostId);
         } else {
-            return reportDashboardRepository.getPostAbuseReports(
-                    ReportPageSize.create(record.size()), record.status(), null);
+            readModels = reportDashboardRepository.getPostAbuseReports(
+                    ReportPageSize.create(reportPageSize), record.status(), null);
+        }
+
+        if (readModels.size() == reportPageSize) { // hasNext == true
+            List<PostAbuseReportDashboardReadModel> returnedReadModels =
+                    readModels.subList(0, reportPageSize - 1);
+            return PostAbuseReportDashboardResponse.of(
+                    returnedReadModels, returnedReadModels.getLast().ulid(), true);
+        } else { // hasNext == false
+            return PostAbuseReportDashboardResponse.of(
+                    readModels, readModels.getLast().ulid(), false);
         }
     }
 
@@ -89,18 +118,36 @@ public class MemberAdminController {
         return reportDashboardRepository.approvePostAbuseReport(postId);
     }
 
-    public List<CommentAbuseReportDashboardReadModel> getCommentAbuseReport(CommentAbuseReportGetRecord record) {
+    public CommentAbuseReportDashboardResponse getCommentAbuseReport(CommentAbuseReportGetRecord record) {
+        int reportPageSize = record.size() + 1;
+        List<CommentAbuseReportDashboardReadModel> readModels;
         if (!(record.lastPostUlid() == null && record.lastPath() == null)) {
             ActivitySubjectCommentId activitySubjectCommentId =
                     ActivitySubjectCommentId.create(
                             ActivitySubjectPostId.create(record.lastPostUlid()),
                             ActivitySubjectCommentPath.create(record.lastPath()));
             memberValidationHelper.validateIfActivitySubjectCommentExists(activitySubjectCommentId);
-            return reportDashboardRepository.getCommentAbuseReports(
-                    ReportPageSize.create(record.size()), record.status(), activitySubjectCommentId);
+            readModels = reportDashboardRepository.getCommentAbuseReports(
+                    ReportPageSize.create(reportPageSize), record.status(), activitySubjectCommentId);
         } else {
-            return reportDashboardRepository.getCommentAbuseReports(
-                    ReportPageSize.create(record.size()), record.status(), null);
+            readModels = reportDashboardRepository.getCommentAbuseReports(
+                    ReportPageSize.create(reportPageSize), record.status(), null);
+        }
+
+        if (readModels.size() == reportPageSize) { // hasNext == true
+            List<CommentAbuseReportDashboardReadModel> returnedReadModels =
+                    readModels.subList(0, reportPageSize - 1);
+            return CommentAbuseReportDashboardResponse.of(
+                    returnedReadModels,
+                    returnedReadModels.getLast().postUlid(),
+                    returnedReadModels.getLast().path(),
+                    true);
+        } else { // hasNext == false
+            return CommentAbuseReportDashboardResponse.of(
+                    readModels,
+                    readModels.getLast().postUlid(),
+                    readModels.getLast().path(),
+                    false);
         }
     }
 

--- a/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberAdminController.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberAdminController.java
@@ -76,6 +76,9 @@ public class MemberAdminController {
     public void removeProposalOrBug(ProposalOrBugReportRemoveRecord record) {
         ReportId reportId = ReportId.create(record.reportUlid());
         if (reportRepository.isIdExistInProposalOrBugReport(reportId)) {
+            if (reportRepository.isUncheckedInProposalOrBugReport(reportId)) {
+                throw new ExistsValueException(NOT_FOUND_PROPOSAL_OR_BUG_REPORT_CHECKED, "checkedAt");
+            }
             reportRepository.removeProposalOrBugReport(reportId);
         }
     }

--- a/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberAdminController.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberAdminController.java
@@ -54,8 +54,13 @@ public class MemberAdminController {
             return ProposalOrBugReportDashboardResponse.of(
                     returnedReadModels, returnedReadModels.getLast().ulid(), true);
         } else { // hasNext == false
-            return ProposalOrBugReportDashboardResponse.of(
-                    readModels, readModels.getLast().ulid(), false);
+            if (!readModels.isEmpty()) {
+                return ProposalOrBugReportDashboardResponse.of(
+                        readModels, readModels.getLast().ulid(), false);
+            } else {
+                return ProposalOrBugReportDashboardResponse.of(
+                        readModels, null, false);
+            }
         }
     }
 
@@ -94,8 +99,13 @@ public class MemberAdminController {
             return PostAbuseReportDashboardResponse.of(
                     returnedReadModels, returnedReadModels.getLast().ulid(), true);
         } else { // hasNext == false
-            return PostAbuseReportDashboardResponse.of(
-                    readModels, readModels.getLast().ulid(), false);
+            if (!readModels.isEmpty()) {
+                return PostAbuseReportDashboardResponse.of(
+                        readModels, readModels.getLast().ulid(), false);
+            } else {
+                return PostAbuseReportDashboardResponse.of(
+                        readModels, null, false);
+            }
         }
     }
 
@@ -143,11 +153,13 @@ public class MemberAdminController {
                     returnedReadModels.getLast().path(),
                     true);
         } else { // hasNext == false
-            return CommentAbuseReportDashboardResponse.of(
-                    readModels,
-                    readModels.getLast().postUlid(),
-                    readModels.getLast().path(),
-                    false);
+            if (!readModels.isEmpty()) {
+                return CommentAbuseReportDashboardResponse.of(
+                        readModels, readModels.getLast().postUlid(), readModels.getLast().path(), false);
+            } else {
+                return CommentAbuseReportDashboardResponse.of(
+                        readModels, null, null, false);
+            }
         }
     }
 

--- a/src/main/java/kr/modusplant/domains/member/adapter/listener/MemberEventListener.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/listener/MemberEventListener.java
@@ -15,7 +15,9 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.support.TransactionTemplate;
 
+import java.util.Arrays;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -25,29 +27,31 @@ public class MemberEventListener {
     private final Semaphore adminSemaphore;
     private final MemberValidationHelper memberValidationHelper;
     private final ReportDashboardRepository reportDashboardRepository;
+    private final TransactionTemplate transactionTemplate;
 
     @Value("${app.semaphore.datasource.bulkhead.admin.timeout-ms}")
     private long timeoutMs;
 
     public MemberEventListener(@Qualifier("adminSemaphore") Semaphore adminSemaphore,
                                MemberValidationHelper memberValidationHelper,
-                               ReportDashboardRepository reportDashboardRepository) {
+                               ReportDashboardRepository reportDashboardRepository, TransactionTemplate transactionTemplate) {
         this.adminSemaphore = adminSemaphore;
         this.memberValidationHelper = memberValidationHelper;
         this.reportDashboardRepository = reportDashboardRepository;
+        this.transactionTemplate = transactionTemplate;
     }
 
     @Async("memberDomainExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void reflectReportDashboard(PostAbuseReportEvent event) {
         acquireAndProcess(
-                () -> {
+                () -> transactionTemplate.executeWithoutResult(status -> {
                     ActivitySubjectPostId postId = ActivitySubjectPostId.create(event.getPostUlid());
                     ReportTime reportTime = ReportTime.create(event.getCreatedAt());
                     memberValidationHelper.validateIfActivitySubjectPostExists(postId);
 
                     reportDashboardRepository.reflectPostAbuseReport(postId, reportTime);
-                },
+                }),
                 "[Member Domain] 게시글 신고 대시보드 삽입 또는 갱신 실패 - postUlid = {}, createdAt = {}",
                 event.getPostUlid(), event.getCreatedAt()
         );
@@ -57,7 +61,7 @@ public class MemberEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void reflectReportDashboard(CommentAbuseReportEvent event) {
         acquireAndProcess(
-                () -> {
+                () -> transactionTemplate.executeWithoutResult(status -> {
                     ActivitySubjectCommentId commentId =
                             ActivitySubjectCommentId.create(
                                     ActivitySubjectPostId.create(event.getPostUlid()),
@@ -66,7 +70,7 @@ public class MemberEventListener {
                     memberValidationHelper.validateIfActivitySubjectCommentExists(commentId);
 
                     reportDashboardRepository.reflectCommentAbuseReport(commentId, reportTime);
-                },
+                }),
                 "[Member Domain] 댓글 신고 대시보드 삽입 또는 갱신 실패 - postUlid = {}, path = {}, createdAt = {}",
                 event.getPostUlid(), event.getPath(), event.getCreatedAt()
         );
@@ -89,7 +93,9 @@ public class MemberEventListener {
             }
             task.run();
         } catch (Exception e) {
-            log.error(errorMsg, args, e);
+            Object[] newArgs = Arrays.copyOf(args, args.length + 1);
+            newArgs[args.length] = e;
+            log.error(errorMsg, newArgs);
         } finally {
             if (acquired) {
                 adminSemaphore.release();

--- a/src/main/java/kr/modusplant/domains/member/domain/enums/AbuseReportStatus.java
+++ b/src/main/java/kr/modusplant/domains/member/domain/enums/AbuseReportStatus.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum AbuseReportStatus {
     UNCHECKED("미확인"),
-    DISMISSED("반려함"),
+    DISMISSED("반려됨"),
     BLINDED("숨겨짐");
 
     private final String value;

--- a/src/main/java/kr/modusplant/domains/member/domain/event/CommentAbuseReportDismissEvent.java
+++ b/src/main/java/kr/modusplant/domains/member/domain/event/CommentAbuseReportDismissEvent.java
@@ -1,0 +1,24 @@
+package kr.modusplant.domains.member.domain.event;
+
+import kr.modusplant.shared.exception.InvalidValueException;
+import kr.modusplant.shared.framework.jpa.exception.enums.EntityErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentAbuseReportDismissEvent {
+    private final String postUlid;
+    private final String path;
+
+    public static CommentAbuseReportDismissEvent create(String postUlid, String path) {
+        if (StringUtils.isBlank(postUlid)) {
+            throw new InvalidValueException(EntityErrorCode.NOT_FOUND_COMMENT, "postUlid");
+        } else if (StringUtils.isBlank(path)) {
+            throw new InvalidValueException(EntityErrorCode.NOT_FOUND_COMMENT, "path");
+        }
+        return new CommentAbuseReportDismissEvent(postUlid, path);
+    }
+}

--- a/src/main/java/kr/modusplant/domains/member/domain/event/PostAbuseReportDismissEvent.java
+++ b/src/main/java/kr/modusplant/domains/member/domain/event/PostAbuseReportDismissEvent.java
@@ -1,0 +1,21 @@
+package kr.modusplant.domains.member.domain.event;
+
+import kr.modusplant.shared.exception.InvalidValueException;
+import kr.modusplant.shared.framework.jpa.exception.enums.EntityErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PostAbuseReportDismissEvent {
+    private final String postUlid;
+
+    public static PostAbuseReportDismissEvent create(String postUlid) {
+        if (StringUtils.isBlank(postUlid)) {
+            throw new InvalidValueException(EntityErrorCode.NOT_FOUND_POST, "postUlid");
+        }
+        return new PostAbuseReportDismissEvent(postUlid);
+    }
+}

--- a/src/main/java/kr/modusplant/domains/member/domain/exception/enums/MemberErrorCode.java
+++ b/src/main/java/kr/modusplant/domains/member/domain/exception/enums/MemberErrorCode.java
@@ -66,6 +66,7 @@ public enum MemberErrorCode implements ErrorCode {
     NOT_FOUND_POST_ABUSE_REPORT(HttpStatus.NOT_FOUND.value(), "not_found_post_abuse_report", "게시글 신고를 찾을 수 없습니다. "),
     NOT_FOUND_POST_ABUSE_REPORT_DASHBOARD(HttpStatus.NOT_FOUND.value(), "not_found_post_abuse_report_dashboard", "게시글 신고 대시보드를 찾을 수 없습니다. "),
     NOT_FOUND_PROPOSAL_OR_BUG_REPORT(HttpStatus.NOT_FOUND.value(), "not_found_proposal_or_bug_report", "건의 및 버그 제보를 찾을 수 없습니다. "),
+    NOT_FOUND_PROPOSAL_OR_BUG_REPORT_CHECKED(HttpStatus.NOT_FOUND.value(), "not_found_proposal_or_bug_report_checked", "확인된 건의 및 버그 제보를 찾을 수 없습니다. "),
     NOT_FOUND_REPORT_ID(HttpStatus.NOT_FOUND.value(), "not_found_report_id", "보고서 식별자를 찾을 수 없습니다. "),
 
     NOT_FOUND_PROPOSAL_OR_BUG_REPORT_IMAGE_NUMBER(HttpStatus.INTERNAL_SERVER_ERROR.value(), "not_found_proposal_or_bug_image_number", "건의 및 버그 제보 이미지 개수를 찾을 수 없습니다. "),

--- a/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
@@ -121,7 +121,7 @@ public class MemberAdminRestController {
             description = "게시글 신고 현황을 조회합니다.",
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
-    @GetMapping(value = "/report/post-abuse")
+    @GetMapping(value = "/report/abuse/post")
     public ResponseEntity<DataResponse<PostAbuseReportDashboardResponse>> getPostAbuseReport(
             @Parameter(
                     description = "필터링용 보고서 상태",
@@ -157,7 +157,7 @@ public class MemberAdminRestController {
             description = "게시글 신고를 반려합니다.",
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
-    @PostMapping(value = "/report/post-abuse/{postUlid}/dismiss")
+    @PostMapping(value = "/report/abuse/post/{postUlid}/dismiss")
     public ResponseEntity<DataResponse<PostAbuseReportDashboardReadModel>> dismissPostAbuseReport(
             @Parameter(
                     description = "반려할 게시글의 식별자",
@@ -177,7 +177,7 @@ public class MemberAdminRestController {
             description = "게시글 신고를 수리합니다.",
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
-    @PostMapping(value = "/report/post-abuse/{postUlid}/approve")
+    @PostMapping(value = "/report/abuse/post/{postUlid}/approve")
     public ResponseEntity<DataResponse<PostAbuseReportDashboardReadModel>> approvePostAbuseReport(
             @Parameter(
                     description = "수리할 게시글의 식별자",
@@ -197,7 +197,7 @@ public class MemberAdminRestController {
             description = "댓글 신고 현황을 조회합니다.",
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
-    @GetMapping(value = "/report/comment-abuse")
+    @GetMapping(value = "/report/abuse/comment")
     public ResponseEntity<DataResponse<CommentAbuseReportDashboardResponse>> getCommentAbuseReport(
             @Parameter(
                     description = "필터링용 보고서 상태",
@@ -242,7 +242,7 @@ public class MemberAdminRestController {
             description = "댓글 신고를 반려합니다.",
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
-    @PostMapping(value = "/report/comment-abuse/{postUlid}/dismiss")
+    @PostMapping(value = "/report/abuse/comment/{postUlid}/dismiss")
     public ResponseEntity<DataResponse<CommentAbuseReportDashboardReadModel>> dismissCommentAbuseReport(
             @Parameter(
                     description = "반려할 댓글이 속한 게시글의 식별자",
@@ -271,7 +271,7 @@ public class MemberAdminRestController {
             description = "댓글 신고를 수리합니다.",
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
-    @PostMapping(value = "/report/comment-abuse/{postUlid}/approve")
+    @PostMapping(value = "/report/abuse/comment/{postUlid}/approve")
     public ResponseEntity<DataResponse<CommentAbuseReportDashboardReadModel>> approveCommentAbuseReport(
             @Parameter(
                     description = "수리할 댓글이 속한 게시글의 식별자",

--- a/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
@@ -13,15 +13,10 @@ import kr.modusplant.domains.member.domain.enums.ProposalOrBugReportStatus;
 import kr.modusplant.domains.member.usecase.model.read.CommentAbuseReportDashboardReadModel;
 import kr.modusplant.domains.member.usecase.model.read.PostAbuseReportDashboardReadModel;
 import kr.modusplant.domains.member.usecase.model.read.ProposalOrBugReportDashboardReadModel;
-import kr.modusplant.domains.member.usecase.record.CommentAbuseReportApproveRecord;
-import kr.modusplant.domains.member.usecase.record.CommentAbuseReportDismissRecord;
-import kr.modusplant.domains.member.usecase.record.CommentAbuseReportGetRecord;
-import kr.modusplant.domains.member.usecase.record.PostAbuseReportApproveRecord;
-import kr.modusplant.domains.member.usecase.record.PostAbuseReportDismissRecord;
-import kr.modusplant.domains.member.usecase.record.PostAbuseReportGetRecord;
-import kr.modusplant.domains.member.usecase.record.ProposalOrBugReportCheckRecord;
-import kr.modusplant.domains.member.usecase.record.ProposalOrBugReportGetRecord;
-import kr.modusplant.domains.member.usecase.record.ProposalOrBugReportRemoveRecord;
+import kr.modusplant.domains.member.usecase.record.*;
+import kr.modusplant.domains.member.usecase.response.CommentAbuseReportDashboardResponse;
+import kr.modusplant.domains.member.usecase.response.PostAbuseReportDashboardResponse;
+import kr.modusplant.domains.member.usecase.response.ProposalOrBugReportDashboardResponse;
 import kr.modusplant.shared.framework.jackson.http.response.DataResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +27,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 import static kr.modusplant.shared.constant.Regex.REGEX_MATERIALIZED_PATH;
 import static kr.modusplant.shared.constant.Regex.REGEX_ULID;
@@ -54,7 +47,7 @@ public class MemberAdminRestController {
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
     @GetMapping(value = "/report/proposal-or-bug")
-    public ResponseEntity<DataResponse<List<ProposalOrBugReportDashboardReadModel>>> getProposalOrBugReport(
+    public ResponseEntity<DataResponse<ProposalOrBugReportDashboardResponse>> getProposalOrBugReport(
             @Parameter(
                     description = "필터링용 보고서 상태",
                     example = "UNCHECKED"
@@ -77,11 +70,11 @@ public class MemberAdminRestController {
             @Range(min = 1, max = 50)
             Integer size) {
 
-        List<ProposalOrBugReportDashboardReadModel> readModels =
+        ProposalOrBugReportDashboardResponse response =
                 memberAdminController.getProposalOrBug(new ProposalOrBugReportGetRecord(status, lastReportUlid, size));
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noStore().mustRevalidate().cachePrivate())
-                .body(DataResponse.ok(readModels));
+                .body(DataResponse.ok(response));
     }
 
     @Operation(
@@ -129,7 +122,7 @@ public class MemberAdminRestController {
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
     @GetMapping(value = "/report/post-abuse")
-    public ResponseEntity<DataResponse<List<PostAbuseReportDashboardReadModel>>> getPostAbuseReport(
+    public ResponseEntity<DataResponse<PostAbuseReportDashboardResponse>> getPostAbuseReport(
             @Parameter(
                     description = "필터링용 보고서 상태",
                     example = "UNCHECKED"
@@ -152,11 +145,11 @@ public class MemberAdminRestController {
             @Range(min = 1, max = 50)
             Integer size) {
 
-        List<PostAbuseReportDashboardReadModel> readModels =
+        PostAbuseReportDashboardResponse response =
                 memberAdminController.getPostAbuseReport(new PostAbuseReportGetRecord(status, lastPostUlid, size));
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noStore().mustRevalidate().cachePrivate())
-                .body(DataResponse.ok(readModels));
+                .body(DataResponse.ok(response));
     }
 
     @Operation(
@@ -205,7 +198,7 @@ public class MemberAdminRestController {
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
     @GetMapping(value = "/report/comment-abuse")
-    public ResponseEntity<DataResponse<List<CommentAbuseReportDashboardReadModel>>> getCommentAbuseReport(
+    public ResponseEntity<DataResponse<CommentAbuseReportDashboardResponse>> getCommentAbuseReport(
             @Parameter(
                     description = "필터링용 보고서 상태",
                     example = "UNCHECKED"
@@ -236,12 +229,12 @@ public class MemberAdminRestController {
             @Range(min = 1, max = 50)
             Integer size) {
 
-        List<CommentAbuseReportDashboardReadModel> readModels =
+        CommentAbuseReportDashboardResponse response =
                 memberAdminController.getCommentAbuseReport(
                         new CommentAbuseReportGetRecord(status, lastPostUlid, lastPath, size));
         return ResponseEntity.ok()
                 .cacheControl(CacheControl.noStore().mustRevalidate().cachePrivate())
-                .body(DataResponse.ok(readModels));
+                .body(DataResponse.ok(response));
     }
 
     @Operation(

--- a/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
@@ -38,13 +38,13 @@ import static kr.modusplant.shared.constant.Regex.REGEX_ULID;
 @Validated
 @Slf4j
 @PreAuthorize("hasAuthority('ADMIN')")
+@SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
 public class MemberAdminRestController {
     private final MemberAdminController memberAdminController;
 
     @Operation(
             summary = "건의 및 버그 제보 현황 조회 API (무한 스크롤)",
-            description = "건의 사항 또는 버그 제보 현황을 조회합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "건의 사항 또는 버그 제보 현황을 조회합니다."
     )
     @GetMapping(value = "/report/proposal-or-bug")
     public ResponseEntity<DataResponse<ProposalOrBugReportDashboardResponse>> getProposalOrBugReport(
@@ -79,8 +79,7 @@ public class MemberAdminRestController {
 
     @Operation(
             summary = "건의 및 버그 제보 확인 API",
-            description = "건의 사항 또는 버그 제보를 확인합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "건의 사항 또는 버그 제보를 확인합니다."
     )
     @PostMapping(value = "/report/proposal-or-bug/{reportUlid}")
     public ResponseEntity<DataResponse<ProposalOrBugReportDashboardReadModel>> checkProposalOrBugReport(
@@ -99,8 +98,7 @@ public class MemberAdminRestController {
 
     @Operation(
             summary = "건의 및 버그 제보 제거 API",
-            description = "건의 사항 또는 버그 제보를 제거합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "건의 사항 또는 버그 제보를 제거합니다."
     )
     @DeleteMapping(value = "/report/proposal-or-bug/{reportUlid}")
     public ResponseEntity<DataResponse<Void>> removeProposalOrBugReport(
@@ -118,8 +116,7 @@ public class MemberAdminRestController {
 
     @Operation(
             summary = "게시글 신고 현황 조회 API (무한 스크롤)",
-            description = "게시글 신고 현황을 조회합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "게시글 신고 현황을 조회합니다."
     )
     @GetMapping(value = "/report/abuse/post")
     public ResponseEntity<DataResponse<PostAbuseReportDashboardResponse>> getPostAbuseReport(
@@ -154,8 +151,7 @@ public class MemberAdminRestController {
 
     @Operation(
             summary = "게시글 신고 반려 API",
-            description = "게시글 신고를 반려합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "게시글 신고를 반려합니다."
     )
     @PostMapping(value = "/report/abuse/post/{postUlid}/dismiss")
     public ResponseEntity<DataResponse<PostAbuseReportDashboardReadModel>> dismissPostAbuseReport(
@@ -174,8 +170,7 @@ public class MemberAdminRestController {
 
     @Operation(
             summary = "게시글 신고 수리 API",
-            description = "게시글 신고를 수리합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "게시글 신고를 수리합니다."
     )
     @PostMapping(value = "/report/abuse/post/{postUlid}/approve")
     public ResponseEntity<DataResponse<PostAbuseReportDashboardReadModel>> approvePostAbuseReport(
@@ -194,8 +189,7 @@ public class MemberAdminRestController {
 
     @Operation(
             summary = "댓글 신고 현황 조회 API (무한 스크롤)",
-            description = "댓글 신고 현황을 조회합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "댓글 신고 현황을 조회합니다."
     )
     @GetMapping(value = "/report/abuse/comment")
     public ResponseEntity<DataResponse<CommentAbuseReportDashboardResponse>> getCommentAbuseReport(
@@ -239,8 +233,7 @@ public class MemberAdminRestController {
 
     @Operation(
             summary = "댓글 신고 반려 API",
-            description = "댓글 신고를 반려합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "댓글 신고를 반려합니다."
     )
     @PostMapping(value = "/report/abuse/post/{postUlid}/path/{path}/dismiss")
     public ResponseEntity<DataResponse<CommentAbuseReportDashboardReadModel>> dismissCommentAbuseReport(
@@ -268,8 +261,7 @@ public class MemberAdminRestController {
 
     @Operation(
             summary = "댓글 신고 수리 API",
-            description = "댓글 신고를 수리합니다.",
-            security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
+            description = "댓글 신고를 수리합니다."
     )
     @PostMapping(value = "/report/abuse/post/{postUlid}/path/{path}/approve")
     public ResponseEntity<DataResponse<CommentAbuseReportDashboardReadModel>> approveCommentAbuseReport(

--- a/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
@@ -242,7 +242,7 @@ public class MemberAdminRestController {
             description = "댓글 신고를 반려합니다.",
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
-    @PostMapping(value = "/report/abuse/comment/{postUlid}/dismiss")
+    @PostMapping(value = "/report/abuse/post/{postUlid}/path/{path}/dismiss")
     public ResponseEntity<DataResponse<CommentAbuseReportDashboardReadModel>> dismissCommentAbuseReport(
             @Parameter(
                     description = "반려할 댓글이 속한 게시글의 식별자",
@@ -257,7 +257,7 @@ public class MemberAdminRestController {
                     description = "반려할 댓글의 경로",
                     schema = @Schema(type = "string", pattern = REGEX_MATERIALIZED_PATH)
             )
-            @RequestParam
+            @PathVariable
             @NotBlank(message = "댓글 경로가 비어 있습니다.")
             @Pattern(regexp = REGEX_MATERIALIZED_PATH, message = "유효하지 않은 댓글 경로 형식입니다. ")
             String path) {
@@ -271,7 +271,7 @@ public class MemberAdminRestController {
             description = "댓글 신고를 수리합니다.",
             security = @SecurityRequirement(name = HttpHeaders.AUTHORIZATION)
     )
-    @PostMapping(value = "/report/abuse/comment/{postUlid}/approve")
+    @PostMapping(value = "/report/abuse/post/{postUlid}/path/{path}/approve")
     public ResponseEntity<DataResponse<CommentAbuseReportDashboardReadModel>> approveCommentAbuseReport(
             @Parameter(
                     description = "수리할 댓글이 속한 게시글의 식별자",
@@ -286,7 +286,7 @@ public class MemberAdminRestController {
                     description = "수리할 댓글의 경로",
                     schema = @Schema(type = "string", pattern = REGEX_MATERIALIZED_PATH)
             )
-            @RequestParam
+            @PathVariable
             @NotBlank(message = "댓글 경로가 비어 있습니다.")
             @Pattern(regexp = REGEX_MATERIALIZED_PATH, message = "유효하지 않은 댓글 경로 형식입니다. ")
             String path) {

--- a/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestController.java
@@ -67,7 +67,7 @@ public class MemberAdminRestController {
                     description = "페이지 크기",
                     schema = @Schema(example = "10", minimum = "1", maximum = "50"))
             @RequestParam
-            @Range(min = 1, max = 50)
+            @Range(min = 1, max = 50, message = "페이지 크기가 범위를 벗어났습니다. ")
             Integer size) {
 
         ProposalOrBugReportDashboardResponse response =
@@ -142,7 +142,7 @@ public class MemberAdminRestController {
                     description = "페이지 크기",
                     schema = @Schema(example = "10", minimum = "1", maximum = "50"))
             @RequestParam
-            @Range(min = 1, max = 50)
+            @Range(min = 1, max = 50, message = "페이지 크기가 범위를 벗어났습니다. ")
             Integer size) {
 
         PostAbuseReportDashboardResponse response =
@@ -226,7 +226,7 @@ public class MemberAdminRestController {
                     description = "페이지 크기",
                     schema = @Schema(example = "10", minimum = "1", maximum = "50"))
             @RequestParam
-            @Range(min = 1, max = 50)
+            @Range(min = 1, max = 50, message = "페이지 크기가 범위를 벗어났습니다. ")
             Integer size) {
 
         CommentAbuseReportDashboardResponse response =

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/ReportDashboardRepositoryAdapter.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/ReportDashboardRepositoryAdapter.java
@@ -61,7 +61,7 @@ public class ReportDashboardRepositoryAdapter implements ReportDashboardReposito
                         .orElseThrow(() ->
                                 new NotFoundEntityException(NOT_FOUND_PROPOSAL_OR_BUG_REPORT, "proposalOrBugReport"));
         proposalOrBugReportEntity.check();
-        proposalOrBugReportJpaRepository.save(proposalOrBugReportEntity);
+        proposalOrBugReportJpaRepository.saveAndFlush(proposalOrBugReportEntity);
         return proposalOrBugReportDashboardJooqRepository.getReadModelByReportId(reportId.getValue());
     }
 
@@ -112,7 +112,7 @@ public class ReportDashboardRepositoryAdapter implements ReportDashboardReposito
                         .orElseThrow(() ->
                                 new NotFoundEntityException(NOT_FOUND_POST_ABUSE_REPORT, "postAbuseReport"));
         entity.dismiss();
-        postAbuseReportDashboardJpaRepository.save(entity);
+        postAbuseReportDashboardJpaRepository.saveAndFlush(entity);
         return postAbuseReportDashboardJooqRepository.getReadModelByPostId(postId.getValue());
     }
 
@@ -123,7 +123,7 @@ public class ReportDashboardRepositoryAdapter implements ReportDashboardReposito
                         .orElseThrow(() ->
                                 new NotFoundEntityException(NOT_FOUND_POST_ABUSE_REPORT, "postAbuseReport"));
         entity.approve();
-        postAbuseReportDashboardJpaRepository.save(entity);
+        postAbuseReportDashboardJpaRepository.saveAndFlush(entity);
         return postAbuseReportDashboardJooqRepository.getReadModelByPostId(postId.getValue());
     }
 
@@ -194,7 +194,7 @@ public class ReportDashboardRepositoryAdapter implements ReportDashboardReposito
                         .orElseThrow(() ->
                                 new NotFoundEntityException(NOT_FOUND_COMMENT_ABUSE_REPORT, "commentAbuseReport"));
         dashboardEntity.dismiss();
-        commentAbuseReportDashboardJpaRepository.save(dashboardEntity);
+        commentAbuseReportDashboardJpaRepository.saveAndFlush(dashboardEntity);
         return commentAbuseReportDashboardJooqRepository.getReadModelByPostUlidAndPath(postUlid, path);
     }
 
@@ -209,7 +209,7 @@ public class ReportDashboardRepositoryAdapter implements ReportDashboardReposito
                         .orElseThrow(() ->
                                 new NotFoundEntityException(NOT_FOUND_COMMENT_ABUSE_REPORT, "commentAbuseReport"));
         dashboardEntity.approve();
-        commentAbuseReportDashboardJpaRepository.save(dashboardEntity);
+        commentAbuseReportDashboardJpaRepository.saveAndFlush(dashboardEntity);
         return commentAbuseReportDashboardJooqRepository.getReadModelByPostUlidAndPath(postUlid, path);
     }
 

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/ReportDashboardRepositoryAdapter.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/ReportDashboardRepositoryAdapter.java
@@ -2,11 +2,7 @@ package kr.modusplant.domains.member.framework.outbound;
 
 import kr.modusplant.domains.member.domain.enums.AbuseReportStatus;
 import kr.modusplant.domains.member.domain.enums.ProposalOrBugReportStatus;
-import kr.modusplant.domains.member.domain.vo.ActivitySubjectCommentId;
-import kr.modusplant.domains.member.domain.vo.ActivitySubjectPostId;
-import kr.modusplant.domains.member.domain.vo.ReportId;
-import kr.modusplant.domains.member.domain.vo.ReportPageSize;
-import kr.modusplant.domains.member.domain.vo.ReportTime;
+import kr.modusplant.domains.member.domain.vo.*;
 import kr.modusplant.domains.member.framework.outbound.jooq.repository.CommentAbuseReportDashboardJooqRepository;
 import kr.modusplant.domains.member.framework.outbound.jooq.repository.PostAbuseReportDashboardJooqRepository;
 import kr.modusplant.domains.member.framework.outbound.jooq.repository.ProposalOrBugReportDashboardJooqRepository;

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/ReportRepositoryAdapter.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/ReportRepositoryAdapter.java
@@ -46,6 +46,11 @@ public class ReportRepositoryAdapter implements ReportRepository {
     }
 
     @Override
+    public boolean isUncheckedInProposalOrBugReport(ReportId reportId) {
+        return proposalOrBugReportJpaRepository.findByUlid(reportId.getValue()).orElseThrow().getCheckedAt() == null;
+    }
+
+    @Override
     public boolean isCheckedInProposalOrBugReport(ReportId reportId) {
         return proposalOrBugReportJpaRepository.findByUlid(reportId.getValue()).orElseThrow().getCheckedAt() != null;
     }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jooq/repository/CommentAbuseReportDashboardJooqRepository.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jooq/repository/CommentAbuseReportDashboardJooqRepository.java
@@ -2,11 +2,13 @@ package kr.modusplant.domains.member.framework.outbound.jooq.repository;
 
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import kr.modusplant.domains.member.domain.enums.AbuseReportStatus;
 import kr.modusplant.domains.member.usecase.model.read.CommentAbuseReportDashboardReadModel;
 import kr.modusplant.shared.framework.jpa.exception.NotFoundEntityException;
 import lombok.RequiredArgsConstructor;
 import org.jooq.*;
 import org.jooq.Record;
+import org.jooq.impl.DSL;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -15,6 +17,7 @@ import java.util.List;
 import static kr.modusplant.domains.member.domain.exception.enums.MemberErrorCode.NOT_FOUND_COMMENT_ABUSE_REPORT;
 import static kr.modusplant.jooq.Tables.*;
 import static org.jooq.impl.DSL.noCondition;
+import static org.jooq.impl.DSL.val;
 
 @Repository
 @RequiredArgsConstructor
@@ -71,6 +74,7 @@ public class CommentAbuseReportDashboardJooqRepository {
                 COMM_COMMENT.CONTENT,
                 COMM_COMMENT_ABUSE_REPORT_DASHBOARD.REPORT_COUNT,
                 COMM_COMMENT_ABUSE_REPORT_DASHBOARD.STATUS,
+                getStatusValueFieldFromCommCommentAbuseReportDashboard(),
                 COMM_COMMENT_ABUSE_REPORT_DASHBOARD.FIRST_REPORTED_AT,
                 COMM_COMMENT_ABUSE_REPORT_DASHBOARD.LAST_REPORTED_AT,
                 getDisplayTimestampField(),
@@ -85,6 +89,7 @@ public class CommentAbuseReportDashboardJooqRepository {
                 record.get(COMM_COMMENT.CONTENT),
                 record.get(COMM_COMMENT_ABUSE_REPORT_DASHBOARD.REPORT_COUNT),
                 record.get(COMM_COMMENT_ABUSE_REPORT_DASHBOARD.STATUS),
+                record.get(getStatusValueFieldFromCommCommentAbuseReportDashboard()),
                 record.get(COMM_COMMENT_ABUSE_REPORT_DASHBOARD.FIRST_REPORTED_AT),
                 record.get(COMM_COMMENT_ABUSE_REPORT_DASHBOARD.LAST_REPORTED_AT),
                 record.get(getDisplayTimestampField()),
@@ -94,5 +99,13 @@ public class CommentAbuseReportDashboardJooqRepository {
 
     private @Nonnull Field<LocalDateTime> getDisplayTimestampField() {
         return COMM_COMMENT_ABUSE_REPORT_DASHBOARD.LAST_REPORTED_AT.as("displayTimestamp");
+    }
+
+    private @Nonnull Field<String> getStatusValueFieldFromCommCommentAbuseReportDashboard() {
+        return DSL.case_(COMM_COMMENT_ABUSE_REPORT_DASHBOARD.STATUS)
+                .when(AbuseReportStatus.UNCHECKED.name(), val(AbuseReportStatus.UNCHECKED.getValue()))
+                .when(AbuseReportStatus.DISMISSED.name(), val(AbuseReportStatus.DISMISSED.getValue()))
+                .otherwise(val(AbuseReportStatus.BLINDED.getValue()))
+                .as("statusValue");
     }
 }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jooq/repository/PostAbuseReportDashboardJooqRepository.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jooq/repository/PostAbuseReportDashboardJooqRepository.java
@@ -3,12 +3,14 @@ package kr.modusplant.domains.member.framework.outbound.jooq.repository;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+import kr.modusplant.domains.member.domain.enums.AbuseReportStatus;
 import kr.modusplant.domains.member.usecase.model.read.PostAbuseReportDashboardReadModel;
 import kr.modusplant.shared.framework.jooq.converter.JsonbJsonNodeConverter;
 import kr.modusplant.shared.framework.jpa.exception.NotFoundEntityException;
 import lombok.RequiredArgsConstructor;
 import org.jooq.*;
 import org.jooq.Record;
+import org.jooq.impl.DSL;
 import org.jspecify.annotations.NonNull;
 import org.springframework.stereotype.Repository;
 
@@ -18,6 +20,7 @@ import java.util.List;
 import static kr.modusplant.domains.member.domain.exception.enums.MemberErrorCode.NOT_FOUND_POST_ABUSE_REPORT;
 import static kr.modusplant.jooq.Tables.*;
 import static org.jooq.impl.DSL.noCondition;
+import static org.jooq.impl.DSL.val;
 
 @Repository
 @RequiredArgsConstructor
@@ -67,6 +70,7 @@ public class PostAbuseReportDashboardJooqRepository {
                 getConvertedContentFieldFromCommPost(),
                 COMM_POST_ABUSE_REPORT_DASHBOARD.REPORT_COUNT,
                 COMM_POST_ABUSE_REPORT_DASHBOARD.STATUS,
+                getStatusValueFieldFromCommPostAbuseReportDashboard(),
                 COMM_POST_ABUSE_REPORT_DASHBOARD.FIRST_REPORTED_AT,
                 COMM_POST_ABUSE_REPORT_DASHBOARD.LAST_REPORTED_AT,
                 getDisplayTimestampFieldFromCommPostAbuseReportDashboard(),
@@ -81,6 +85,7 @@ public class PostAbuseReportDashboardJooqRepository {
                 record.get(getConvertedContentFieldFromCommPost()),
                 record.get(COMM_POST_ABUSE_REPORT_DASHBOARD.REPORT_COUNT),
                 record.get(COMM_POST_ABUSE_REPORT_DASHBOARD.STATUS),
+                record.get(getStatusValueFieldFromCommPostAbuseReportDashboard()),
                 record.get(COMM_POST_ABUSE_REPORT_DASHBOARD.FIRST_REPORTED_AT),
                 record.get(COMM_POST_ABUSE_REPORT_DASHBOARD.LAST_REPORTED_AT),
                 record.get(getDisplayTimestampFieldFromCommPostAbuseReportDashboard()),
@@ -95,4 +100,12 @@ public class PostAbuseReportDashboardJooqRepository {
     private @Nonnull Field<LocalDateTime> getDisplayTimestampFieldFromCommPostAbuseReportDashboard() {
         return COMM_POST_ABUSE_REPORT_DASHBOARD.LAST_REPORTED_AT.as("displayTimestamp");
     }
+
+    private @Nonnull Field<String> getStatusValueFieldFromCommPostAbuseReportDashboard() {
+        return DSL.case_(COMM_POST_ABUSE_REPORT_DASHBOARD.STATUS)
+                .when(AbuseReportStatus.UNCHECKED.name(), val(AbuseReportStatus.UNCHECKED.getValue()))
+                .when(AbuseReportStatus.DISMISSED.name(), val(AbuseReportStatus.DISMISSED.getValue()))
+                .otherwise(val(AbuseReportStatus.BLINDED.getValue()))
+                .as("statusValue");
+        }
 }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jooq/repository/ProposalOrBugReportDashboardJooqRepository.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jooq/repository/ProposalOrBugReportDashboardJooqRepository.java
@@ -42,8 +42,7 @@ public class ProposalOrBugReportDashboardJooqRepository {
             String proposalOrBugReportStatus,
             @Nullable String lastReportId) {
         Field<String> statusName = when(PROP_BUG_REP.CHECKED_AT.isNull(), val(ProposalOrBugReportStatus.UNCHECKED.name()))
-                .otherwise(val(ProposalOrBugReportStatus.CHECKED.name()))
-                .as("status");
+                .otherwise(val(ProposalOrBugReportStatus.CHECKED.name()));
         Condition ulidCondition = lastReportId != null ?
                 PROP_BUG_REP.ULID.lt(lastReportId) : noCondition();
         Condition statusCondition = proposalOrBugReportStatus != null ?
@@ -70,7 +69,8 @@ public class ProposalOrBugReportDashboardJooqRepository {
                 PROP_BUG_REP.CREATED_AT,
                 getDisplayTimeFieldFromPropBugRep(),
                 SITE_MEMBER.NICKNAME,
-                getStatusFieldFromPropBugRep()
+                getStatusFieldFromPropBugRep(),
+                getStatusValueFieldFromPropBugRep()
         };
     }
 
@@ -84,7 +84,8 @@ public class ProposalOrBugReportDashboardJooqRepository {
                 record.get(PROP_BUG_REP.CREATED_AT),
                 record.get(getDisplayTimeFieldFromPropBugRep()),
                 record.get(SITE_MEMBER.NICKNAME),
-                record.get(getStatusFieldFromPropBugRep())
+                record.get(getStatusFieldFromPropBugRep()),
+                record.get(getStatusValueFieldFromPropBugRep())
         );
     }
 
@@ -97,8 +98,14 @@ public class ProposalOrBugReportDashboardJooqRepository {
     }
 
     private @Nonnull Field<String> getStatusFieldFromPropBugRep() {
+        return when(PROP_BUG_REP.CHECKED_AT.isNull(), val(ProposalOrBugReportStatus.UNCHECKED.name()))
+                .otherwise(val(ProposalOrBugReportStatus.CHECKED.name()))
+                .as("status");
+    }
+
+    private @Nonnull Field<String> getStatusValueFieldFromPropBugRep() {
         return when(PROP_BUG_REP.CHECKED_AT.isNull(), val(ProposalOrBugReportStatus.UNCHECKED.getValue()))
                 .otherwise(val(ProposalOrBugReportStatus.CHECKED.getValue()))
-                .as("status");
+                .as("statusValue");
     }
 }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/compositekey/CommentAbuseReportDashboardCompositeKey.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/compositekey/CommentAbuseReportDashboardCompositeKey.java
@@ -1,6 +1,9 @@
 package kr.modusplant.domains.member.framework.outbound.jpa.compositekey;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/compositekey/PostAbuseReportCompositeKey.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/compositekey/PostAbuseReportCompositeKey.java
@@ -14,5 +14,5 @@ import java.util.UUID;
 @EqualsAndHashCode
 public class PostAbuseReportCompositeKey implements Serializable {
     private UUID memberId;
-    private String post;
+    private String postId;
 }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/entity/CommentAbuseReportDashboardEntity.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/entity/CommentAbuseReportDashboardEntity.java
@@ -13,9 +13,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
-import static kr.modusplant.shared.persistence.constant.TableColumnName.PATH;
-import static kr.modusplant.shared.persistence.constant.TableColumnName.POST_ULID;
-import static kr.modusplant.shared.persistence.constant.TableColumnName.VER_NUM;
+import static kr.modusplant.shared.persistence.constant.TableColumnName.*;
 import static kr.modusplant.shared.persistence.constant.TableName.COMM_COMMENT_ABUSE_REPORT_DASHBOARD;
 
 @Entity

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/entity/PostAbuseReportDashboardEntity.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/entity/PostAbuseReportDashboardEntity.java
@@ -27,7 +27,7 @@ public class PostAbuseReportDashboardEntity {
     @Id
     private String postUlid;
 
-    @MapsId("postUlid")
+    @MapsId
     @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE}, optional = false)
     @JoinColumn(name = POST_ULID, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     @ToString.Exclude

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/entity/PostAbuseReportEntity.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/entity/PostAbuseReportEntity.java
@@ -36,6 +36,9 @@ public class PostAbuseReportEntity {
     private MemberEntity member;
 
     @Id
+    private String postId;
+
+    @MapsId("postId")
     @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE}, optional = false)
     @JoinColumn(name = POST_ULID, foreignKey = @ForeignKey(value = ConstraintMode.NO_CONSTRAINT))
     @ToString.Exclude

--- a/src/main/java/kr/modusplant/domains/member/usecase/model/read/CommentAbuseReportDashboardReadModel.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/model/read/CommentAbuseReportDashboardReadModel.java
@@ -8,6 +8,7 @@ public record CommentAbuseReportDashboardReadModel(
         String content,
         Integer reportCount,
         String status,
+        String statusValue,
         LocalDateTime firstReportedAt,
         LocalDateTime lastReportedAt,
         LocalDateTime displayTimestamp,

--- a/src/main/java/kr/modusplant/domains/member/usecase/model/read/PostAbuseReportDashboardReadModel.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/model/read/PostAbuseReportDashboardReadModel.java
@@ -10,6 +10,7 @@ public record PostAbuseReportDashboardReadModel(
         JsonNode content,
         Integer reportCount,
         String status,
+        String statusValue,
         LocalDateTime firstReportedAt,
         LocalDateTime lastReportedAt,
         LocalDateTime displayTimestamp,

--- a/src/main/java/kr/modusplant/domains/member/usecase/model/read/ProposalOrBugReportDashboardReadModel.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/model/read/ProposalOrBugReportDashboardReadModel.java
@@ -13,5 +13,6 @@ public record ProposalOrBugReportDashboardReadModel(
         LocalDateTime createdAt,
         LocalDateTime displayTimestamp,
         String nickname,
-        String status) {
+        String status,
+        String statusValue) {
 }

--- a/src/main/java/kr/modusplant/domains/member/usecase/port/repository/ReportRepository.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/port/repository/ReportRepository.java
@@ -13,6 +13,8 @@ import kr.modusplant.domains.member.domain.vo.*;
 public interface ReportRepository {
     boolean isIdExistInProposalOrBugReport(ReportId reportId);
 
+    boolean isUncheckedInProposalOrBugReport(ReportId reportId);
+
     boolean isCheckedInProposalOrBugReport(ReportId reportId);
 
     boolean isMemberAbusePost(MemberId memberId, ActivitySubjectPostId activitySubjectPostId);

--- a/src/main/java/kr/modusplant/domains/member/usecase/response/CommentAbuseReportDashboardResponse.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/response/CommentAbuseReportDashboardResponse.java
@@ -1,0 +1,31 @@
+package kr.modusplant.domains.member.usecase.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.modusplant.domains.member.usecase.model.read.CommentAbuseReportDashboardReadModel;
+
+import java.util.List;
+
+public record CommentAbuseReportDashboardResponse(
+        @Schema(description = "조회된 읽기 모델")
+        List<CommentAbuseReportDashboardReadModel> readModels,
+
+        @Schema(description = "마지막 게시글 ID", example = "01JY3PPG5YJ41H7BPD0DSQW2RA")
+        String lastPostUlid,
+
+        @Schema(description = "마지막 댓글 경로", example = "1.4.5")
+        String lastPath,
+
+        @Schema(description = "다음 댓글 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "페이지 크기", example = "10")
+        int size) {
+    public static CommentAbuseReportDashboardResponse of(
+            List<CommentAbuseReportDashboardReadModel> readModels,
+            String lastPostUlid,
+            String nextPath,
+            boolean hasNext) {
+        return new CommentAbuseReportDashboardResponse(
+                readModels, lastPostUlid, nextPath, hasNext, readModels.size());
+    }
+}

--- a/src/main/java/kr/modusplant/domains/member/usecase/response/PostAbuseReportDashboardResponse.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/response/PostAbuseReportDashboardResponse.java
@@ -1,0 +1,26 @@
+package kr.modusplant.domains.member.usecase.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.modusplant.domains.member.usecase.model.read.PostAbuseReportDashboardReadModel;
+
+import java.util.List;
+
+public record PostAbuseReportDashboardResponse(
+        @Schema(description = "조회된 읽기 모델")
+        List<PostAbuseReportDashboardReadModel> readModels,
+
+        @Schema(description = "마지막 게시글 ID", example = "01JY3PPG5YJ41H7BPD0DSQW2RA")
+        String lastPostUlid,
+
+        @Schema(description = "다음 게시글 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "페이지 크기", example = "10")
+        int size) {
+    public static PostAbuseReportDashboardResponse of(
+            List<PostAbuseReportDashboardReadModel> readModels,
+            String lastPostUlid,
+            boolean hasNext) {
+        return new PostAbuseReportDashboardResponse(readModels, lastPostUlid, hasNext, readModels.size());
+    }
+}

--- a/src/main/java/kr/modusplant/domains/member/usecase/response/ProposalOrBugReportDashboardResponse.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/response/ProposalOrBugReportDashboardResponse.java
@@ -1,0 +1,31 @@
+package kr.modusplant.domains.member.usecase.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.modusplant.domains.member.usecase.model.read.ProposalOrBugReportDashboardReadModel;
+
+import java.util.List;
+
+public record ProposalOrBugReportDashboardResponse (
+        @Schema(description = "조회된 읽기 모델")
+        List<ProposalOrBugReportDashboardReadModel> readModels,
+
+        @Schema(description = "마지막 보고서 ID", example = "01JY3PPG5YJ41H7BPD0DSQW2RA")
+        String lastReportUlid,
+
+        @Schema(description = "다음 보고서 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "페이지 크기", example = "10")
+        int size) {
+    public static ProposalOrBugReportDashboardResponse of(
+            List<ProposalOrBugReportDashboardReadModel> readModels,
+            String lastReportUlid,
+            boolean hasNext) {
+        return new ProposalOrBugReportDashboardResponse(
+                readModels,
+                lastReportUlid,
+                hasNext,
+                readModels.size()
+        );
+    }
+}

--- a/src/main/java/kr/modusplant/domains/notification/framework/inbound/web/listener/NotificationEventListener.java
+++ b/src/main/java/kr/modusplant/domains/notification/framework/inbound/web/listener/NotificationEventListener.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Arrays;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -78,7 +79,9 @@ public class NotificationEventListener {
             }
             task.run();
         } catch (Exception e) {
-            log.error(errorMsg, args, e);
+            Object[] newArgs = Arrays.copyOf(args, args.length + 1);
+            newArgs[args.length] = e;
+            log.error(errorMsg, newArgs);
         } finally {
             if (acquired) {
                 notificationSemaphore.release();

--- a/src/test/java/kr/modusplant/domains/comment/common/constant/CommentConstant.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/constant/CommentConstant.java
@@ -7,12 +7,12 @@ import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CommentConstant {
-    public static final String TEST_COMM_COMMENT_PATH = "1.6.2";
-    public static final String TEST_COMM_COMMENT_CONTENT = "테스트 댓글 내용";
-    public static final Integer TEST_COMM_COMMENT_LIKE_COUNT = 1;
-    public static final Boolean TEST_COMM_POST_IS_DELETED_TRUE = true;
-    public static final Boolean TEST_COMM_POST_IS_DELETED_FALSE = false;
-    public static final LocalDateTime TEST_COMM_COMMENT_CREATED_AT = LocalDateTime.of(2026, 4, 25, 0, 0);
-    public static final LocalDateTime TEST_COMM_COMMENT_UPDATED_AT = LocalDateTime.of(2026, 4, 27, 12, 0);
-    public static final LocalDateTime TEST_COMM_COMMENT_EDITED_AT = LocalDateTime.of(2026, 4, 28, 5, 0);
+    public static final String TEST_COMMENT_PATH = "1.6.2";
+    public static final String TEST_COMMENT_CONTENT = "테스트 댓글 내용";
+    public static final Integer TEST_COMMENT_LIKE_COUNT = 1;
+    public static final Boolean TEST_POST_IS_DELETED_TRUE = true;
+    public static final Boolean TEST_POST_IS_DELETED_FALSE = false;
+    public static final LocalDateTime TEST_COMMENT_CREATED_AT = LocalDateTime.of(2026, 4, 25, 0, 0);
+    public static final LocalDateTime TEST_COMMENT_UPDATED_AT = LocalDateTime.of(2026, 4, 27, 12, 0);
+    public static final LocalDateTime TEST_COMMENT_EDITED_AT = LocalDateTime.of(2026, 4, 28, 5, 0);
 }

--- a/src/test/java/kr/modusplant/domains/comment/common/util/domain/CommentContentTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/util/domain/CommentContentTestUtils.java
@@ -2,8 +2,8 @@ package kr.modusplant.domains.comment.common.util.domain;
 
 import kr.modusplant.domains.comment.domain.vo.CommentContent;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_CONTENT;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_CONTENT;
 
 public interface CommentContentTestUtils {
-    CommentContent testCommentContent = CommentContent.create(TEST_COMM_COMMENT_CONTENT);
+    CommentContent testCommentContent = CommentContent.create(TEST_COMMENT_CONTENT);
 }

--- a/src/test/java/kr/modusplant/domains/comment/common/util/domain/CommentPathTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/util/domain/CommentPathTestUtils.java
@@ -2,8 +2,8 @@ package kr.modusplant.domains.comment.common.util.domain;
 
 import kr.modusplant.domains.comment.domain.vo.CommentPath;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 
 public interface CommentPathTestUtils {
-    CommentPath testCommentPath = CommentPath.create(TEST_COMM_COMMENT_PATH);
+    CommentPath testCommentPath = CommentPath.create(TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/comment/common/util/framework/outbound/persistence/jpa/compositekey/CommentCompositeKeyTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/util/framework/outbound/persistence/jpa/compositekey/CommentCompositeKeyTestUtils.java
@@ -3,12 +3,12 @@ package kr.modusplant.domains.comment.common.util.framework.outbound.persistence
 import kr.modusplant.domains.comment.common.util.framework.outbound.persistence.jpa.entity.CommentEntityTestUtils;
 import kr.modusplant.domains.comment.framework.outbound.persistence.jpa.compositekey.CommentCompositeKey;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentCompositeKeyTestUtils extends CommentEntityTestUtils {
     CommentCompositeKey TEST_COMMENT_ID = CommentCompositeKey.builder()
             .post(TEST_POST_ULID)
-            .path(TEST_COMM_COMMENT_PATH)
+            .path(TEST_COMMENT_PATH)
             .build();
 }

--- a/src/test/java/kr/modusplant/domains/comment/common/util/framework/outbound/persistence/jpa/entity/CommentEntityTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/util/framework/outbound/persistence/jpa/entity/CommentEntityTestUtils.java
@@ -9,8 +9,8 @@ import static kr.modusplant.domains.comment.framework.outbound.persistence.jpa.e
 public interface CommentEntityTestUtils extends PostEntityTestUtils {
     default CommentEntityBuilder createCommentEntityBuilder() {
         return builder()
-                .path(TEST_COMM_COMMENT_PATH)
-                .likeCount(TEST_COMM_COMMENT_LIKE_COUNT)
-                .content(TEST_COMM_COMMENT_CONTENT);
+                .path(TEST_COMMENT_PATH)
+                .likeCount(TEST_COMMENT_LIKE_COUNT)
+                .content(TEST_COMMENT_CONTENT);
     }
 }

--- a/src/test/java/kr/modusplant/domains/comment/common/util/usecase/model/CommentOfAuthorPageModelTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/util/usecase/model/CommentOfAuthorPageModelTestUtils.java
@@ -2,15 +2,15 @@ package kr.modusplant.domains.comment.common.util.usecase.model;
 
 import kr.modusplant.domains.comment.usecase.model.CommentOfAuthorPageModel;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_CONTENT;
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_CREATED_AT;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_CONTENT;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_CREATED_AT;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_TITLE;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentOfAuthorPageModelTestUtils {
 
     CommentOfAuthorPageModel testCommentOfAuthorPageModel = new CommentOfAuthorPageModel(
-            TEST_COMM_COMMENT_CONTENT, TEST_COMM_COMMENT_CREATED_AT,
+            TEST_COMMENT_CONTENT, TEST_COMMENT_CREATED_AT,
             TEST_POST_TITLE, TEST_POST_ULID, false, 1
     );
 }

--- a/src/test/java/kr/modusplant/domains/comment/common/util/usecase/model/CommentOfPostReadModelTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/util/usecase/model/CommentOfPostReadModelTestUtils.java
@@ -9,8 +9,8 @@ import static kr.modusplant.domains.member.common.constant.MemberProfileConstant
 public interface CommentOfPostReadModelTestUtils {
 
     CommentOfPostReadModel testCommentOfPostReadModel = new CommentOfPostReadModel(
-            MEMBER_PROFILE_BASIC_USER_IMAGE_PATH, MEMBER_BASIC_USER_NICKNAME, TEST_COMM_COMMENT_PATH,
-            TEST_COMM_COMMENT_CONTENT, TEST_COMM_COMMENT_LIKE_COUNT, false,
-            TEST_COMM_COMMENT_CREATED_AT, TEST_COMM_COMMENT_EDITED_AT, TEST_COMM_POST_IS_DELETED_FALSE
+            MEMBER_PROFILE_BASIC_USER_IMAGE_PATH, MEMBER_BASIC_USER_NICKNAME, TEST_COMMENT_PATH,
+            TEST_COMMENT_CONTENT, TEST_COMMENT_LIKE_COUNT, false,
+            TEST_COMMENT_CREATED_AT, TEST_COMMENT_EDITED_AT, TEST_POST_IS_DELETED_FALSE
     );
 }

--- a/src/test/java/kr/modusplant/domains/comment/common/util/usecase/response/CommentOfPostResponseTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/util/usecase/response/CommentOfPostResponseTestUtils.java
@@ -8,8 +8,8 @@ import static kr.modusplant.domains.member.common.constant.MemberProfileConstant
 
 public interface CommentOfPostResponseTestUtils {
     CommentOfPostResponse testCommentOfPostResponse = new CommentOfPostResponse(
-            MEMBER_PROFILE_BASIC_USER_IMAGE_PATH, MEMBER_BASIC_USER_NICKNAME, TEST_COMM_COMMENT_PATH,
-            TEST_COMM_COMMENT_CONTENT, TEST_COMM_COMMENT_LIKE_COUNT, false,
-            TEST_COMM_COMMENT_CREATED_AT, TEST_COMM_COMMENT_EDITED_AT, TEST_COMM_POST_IS_DELETED_FALSE
+            MEMBER_PROFILE_BASIC_USER_IMAGE_PATH, MEMBER_BASIC_USER_NICKNAME, TEST_COMMENT_PATH,
+            TEST_COMMENT_CONTENT, TEST_COMMENT_LIKE_COUNT, false,
+            TEST_COMMENT_CREATED_AT, TEST_COMMENT_EDITED_AT, TEST_POST_IS_DELETED_FALSE
     );
 }

--- a/src/test/java/kr/modusplant/domains/comment/common/util/usecase/response/CommentResponseTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/comment/common/util/usecase/response/CommentResponseTestUtils.java
@@ -6,7 +6,7 @@ import kr.modusplant.domains.comment.common.util.domain.PostIdTestUtils;
 import kr.modusplant.domains.comment.usecase.response.CommentResponse;
 import kr.modusplant.shared.kernel.common.util.NicknameTestUtils;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_CREATED_AT;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_CREATED_AT;
 
 public interface CommentResponseTestUtils extends
         PostIdTestUtils, CommentPathTestUtils,
@@ -14,6 +14,6 @@ public interface CommentResponseTestUtils extends
 
     CommentResponse testCommentResponse = new CommentResponse(
             testPostId.getId(), testCommentPath.getPath(), testNormalUserNickname.getValue(),
-            testCommentContent.getContent(), false, TEST_COMM_COMMENT_CREATED_AT.toString()
+            testCommentContent.getContent(), false, TEST_COMMENT_CREATED_AT.toString()
     );
 }

--- a/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberAdminControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberAdminControllerTest.java
@@ -13,6 +13,9 @@ import kr.modusplant.domains.member.usecase.port.repository.ReportRepository;
 import kr.modusplant.domains.member.usecase.record.CommentAbuseReportGetRecord;
 import kr.modusplant.domains.member.usecase.record.PostAbuseReportGetRecord;
 import kr.modusplant.domains.member.usecase.record.ProposalOrBugReportGetRecord;
+import kr.modusplant.domains.member.usecase.response.CommentAbuseReportDashboardResponse;
+import kr.modusplant.domains.member.usecase.response.PostAbuseReportDashboardResponse;
+import kr.modusplant.domains.member.usecase.response.ProposalOrBugReportDashboardResponse;
 import kr.modusplant.shared.exception.ExistsValueException;
 import kr.modusplant.shared.framework.jackson.holder.ObjectMapperHolder;
 import kr.modusplant.shared.framework.jpa.exception.NotFoundEntityException;
@@ -42,6 +45,12 @@ import static kr.modusplant.domains.member.common.util.usecase.record.PostAbuseR
 import static kr.modusplant.domains.member.common.util.usecase.record.ProposalOrBugReportCheckRecordTestUtils.testProposalOrBugReportCheckRecord;
 import static kr.modusplant.domains.member.common.util.usecase.record.ProposalOrBugReportRecordGetTestUtils.testProposalOrBugReportGetRecord;
 import static kr.modusplant.domains.member.common.util.usecase.record.ProposalOrBugReportRemoveRecordTestUtils.testProposalOrBugReportRemoveRecord;
+import static kr.modusplant.domains.member.common.util.usecase.response.CommentAbuseDashboardResponseTestUtils.testCommentAbuseReportDashboardResponseWithFalseHasNext;
+import static kr.modusplant.domains.member.common.util.usecase.response.CommentAbuseDashboardResponseTestUtils.testCommentAbuseReportDashboardResponseWithTrueHasNext;
+import static kr.modusplant.domains.member.common.util.usecase.response.PostAbuseDashboardResponseTestUtils.testPostAbuseReportDashboardResponseWithFalseHasNext;
+import static kr.modusplant.domains.member.common.util.usecase.response.PostAbuseDashboardResponseTestUtils.testPostAbuseReportDashboardResponseWithTrueHasNext;
+import static kr.modusplant.domains.member.common.util.usecase.response.ProposalOrBugReportDashboardResponseTestUtils.testProposalOrBugReportDashboardResponseWithFalseHasNext;
+import static kr.modusplant.domains.member.common.util.usecase.response.ProposalOrBugReportDashboardResponseTestUtils.testProposalOrBugReportDashboardResponseWithTrueHasNext;
 import static kr.modusplant.domains.member.domain.exception.enums.MemberErrorCode.*;
 import static kr.modusplant.infrastructure.config.jackson.JacksonConfig.objectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,33 +74,49 @@ class MemberAdminControllerTest {
     private final MemberAdminController memberAdminController = new MemberAdminController(memberValidationHelper, reportRepository, reportDashboardRepository, applicationEventPublisher);
 
     @Test
-    @DisplayName("lastReportUlid가 null이 아닐 때 getProposalOrBug로 건의 및 버그 제보 조회")
-    void testGetProposalOrBug_givenValidLastReportUlid_willGetProposalOrBugReport() {
+    @DisplayName("lastReportUlid가 null이 아닐 때 getProposalOrBug로 건의 및 버그 제보 현황 응답 반환")
+    void testGetProposalOrBug_givenValidLastReportUlid_willReturnResponse() {
         // given
         willDoNothing().given(memberValidationHelper).validateIfReportExists(any());
         given(reportDashboardRepository.getProposalOrBugReports(any(), any(), any())).willReturn(testProposalOrBugReportDashboardCheckedReadModelList);
 
         // when
-        List<ProposalOrBugReportDashboardReadModel> readModels = memberAdminController.getProposalOrBug(testProposalOrBugReportGetRecord);
+        ProposalOrBugReportDashboardResponse response = memberAdminController.getProposalOrBug(testProposalOrBugReportGetRecord);
 
         // then
         verify(reportDashboardRepository, times(1)).getProposalOrBugReports(any(), any(), any());
-        assertThat(readModels).isEqualTo(testProposalOrBugReportDashboardCheckedReadModelList);
+        assertThat(response).isEqualTo(testProposalOrBugReportDashboardResponseWithFalseHasNext);
     }
 
     @Test
-    @DisplayName("lastReportUlid가 null일 때 getProposalOrBug로 건의 및 버그 제보 조회")
-    void testGetProposalOrBug_givenNullLastReportUlid_willGetProposalOrBugReport() {
+    @DisplayName("lastReportUlid가 null일 때 getProposalOrBug로 건의 및 버그 제보 현황 응답 반환")
+    void testGetProposalOrBug_givenNullLastReportUlid_willReturnResponse() {
         // given
         given(reportDashboardRepository.getProposalOrBugReports(any(), any(), any())).willReturn(testProposalOrBugReportDashboardCheckedReadModelList);
 
         // when
-        List<ProposalOrBugReportDashboardReadModel> readModels =
+        ProposalOrBugReportDashboardResponse response =
                 memberAdminController.getProposalOrBug(new ProposalOrBugReportGetRecord(ProposalOrBugReportStatus.CHECKED, null, TEST_REPORT_SIZE));
 
         // then
         verify(reportDashboardRepository, times(1)).getProposalOrBugReports(any(), any(), any());
-        assertThat(readModels).isEqualTo(testProposalOrBugReportDashboardCheckedReadModelList);
+        assertThat(response).isEqualTo(testProposalOrBugReportDashboardResponseWithFalseHasNext);
+    }
+
+    @Test
+    @DisplayName("페이지 크기보다 더 많은 데이터가 있을 때 getProposalOrBug로 hasNext가 true인 응답 반환")
+    void testGetProposalOrBug_givenMoreItemsThanPageSize_willReturnResponseWithTrueHasNext() {
+        // given
+        given(reportDashboardRepository.getProposalOrBugReports(any(), any(), any()))
+                .willReturn(List.of(testProposalOrBugReportDashboardCheckedReadModel, testProposalOrBugReportDashboardCheckedReadModel));
+
+        // when
+        ProposalOrBugReportDashboardResponse response =
+                memberAdminController.getProposalOrBug(new ProposalOrBugReportGetRecord(ProposalOrBugReportStatus.CHECKED, null, 1));
+
+        // then
+        verify(reportDashboardRepository, times(1)).getProposalOrBugReports(any(), any(), any());
+        assertThat(response).isEqualTo(testProposalOrBugReportDashboardResponseWithTrueHasNext);
     }
 
     @Test
@@ -154,35 +179,50 @@ class MemberAdminControllerTest {
     }
 
     @Test
-    @DisplayName("lastPostUlid가 존재하고 유효할 때 getPostAbuseReport로 게시글 신고 현황 목록 반환")
-    void testGetPostAbuseReport_givenValidLastPostUlid_willReturnReadModelList() {
+    @DisplayName("lastPostUlid가 존재하고 유효할 때 getPostAbuseReport로 게시글 신고 현황 응답 반환")
+    void testGetPostAbuseReport_givenValidLastPostUlid_willReturnResponse() {
         // given
         willDoNothing().given(memberValidationHelper).validateIfActivitySubjectPostExists(any());
         given(reportDashboardRepository.getPostAbuseReports(any(), any(), any())).willReturn(testPostAbuseReportDashboardReadModelList);
 
         // when
-        List<PostAbuseReportDashboardReadModel> readModels = memberAdminController.getPostAbuseReport(testPostAbuseReportGetRecord);
+        PostAbuseReportDashboardResponse response = memberAdminController.getPostAbuseReport(testPostAbuseReportGetRecord);
 
         // then
         verify(reportDashboardRepository, times(1)).getPostAbuseReports(any(), any(), any());
-        assertThat(readModels).isEqualTo(testPostAbuseReportDashboardReadModelList);
+        assertThat(response).isEqualTo(testPostAbuseReportDashboardResponseWithFalseHasNext);
     }
 
     @Test
-    @DisplayName("lastPostUlid가 null일 때 getPostAbuseReport로 게시글 신고 현황 목록 반환")
-    void testGetPostAbuseReport_givenNullLastPostUlid_willReturnReadModelList() {
+    @DisplayName("lastPostUlid가 null일 때 getPostAbuseReport로 게시글 신고 현황 응답 반환")
+    void testGetPostAbuseReport_givenNullLastPostUlid_willReturnResponse() {
         // given
         given(reportDashboardRepository.getPostAbuseReports(any(), any(), any())).willReturn(testPostAbuseReportDashboardReadModelList);
 
         // when
-        List<PostAbuseReportDashboardReadModel> readModels =
+        PostAbuseReportDashboardResponse response =
                 memberAdminController.getPostAbuseReport(new PostAbuseReportGetRecord(AbuseReportStatus.UNCHECKED, null, TEST_REPORT_SIZE));
 
         // then
         verify(reportDashboardRepository, times(1)).getPostAbuseReports(any(), any(), any());
-        assertThat(readModels).isEqualTo(testPostAbuseReportDashboardReadModelList);
+        assertThat(response).isEqualTo(testPostAbuseReportDashboardResponseWithFalseHasNext);
     }
 
+    @Test
+    @DisplayName("페이지 크기보다 더 많은 데이터가 있을 때 getPostAbuseReport로 hasNext가 true인 응답 반환")
+    void testGetPostAbuseReport_givenMoreItemsThanPageSize_willReturnResponseWithTrueHasNext() {
+        // given
+        given(reportDashboardRepository.getPostAbuseReports(any(), any(), any()))
+                .willReturn(List.of(testPostAbuseReportDashboardReadModel, testPostAbuseReportDashboardReadModel));
+
+        // when
+        PostAbuseReportDashboardResponse response =
+                memberAdminController.getPostAbuseReport(new PostAbuseReportGetRecord(AbuseReportStatus.UNCHECKED, null, 1));
+
+        // then
+        verify(reportDashboardRepository, times(1)).getPostAbuseReports(any(), any(), any());
+        assertThat(response).isEqualTo(testPostAbuseReportDashboardResponseWithTrueHasNext);
+    }
 
     @Test
     @DisplayName("lastPostUlid가 존재하지 않을 때 getPostAbuseReport로 예외 반환")
@@ -300,32 +340,48 @@ class MemberAdminControllerTest {
     }
 
     @Test
-    @DisplayName("lastPostUlid와 lastPath 모두 존재하고 유효할 때 getCommentAbuseReport로 댓글 신고 현황 목록 반환")
-    void testGetCommentAbuseReport_givenValidLastPostUlidAndLastPath_willReturnReadModelList() {
+    @DisplayName("lastPostUlid와 lastPath 모두 존재하고 유효할 때 getCommentAbuseReport로 댓글 신고 현황 응답 반환")
+    void testGetCommentAbuseReport_givenValidLastPostUlidAndLastPath_willReturnResponse() {
         // given
         given(reportDashboardRepository.getCommentAbuseReports(any(), any(), any())).willReturn(testCommentAbuseReportDashboardReadModelList);
 
         // when
-        List<CommentAbuseReportDashboardReadModel> readModels = memberAdminController.getCommentAbuseReport(testCommentAbuseReportGetRecord);
+        CommentAbuseReportDashboardResponse response = memberAdminController.getCommentAbuseReport(testCommentAbuseReportGetRecord);
 
         // then
         verify(reportDashboardRepository, times(1)).getCommentAbuseReports(any(), any(), any());
-        assertThat(readModels).isEqualTo(testCommentAbuseReportDashboardReadModelList);
+        assertThat(response).isEqualTo(testCommentAbuseReportDashboardResponseWithFalseHasNext);
     }
 
     @Test
-    @DisplayName("lastPostUlid와 lastPath 모두 null일 때 getCommentAbuseReport로 게시글 신고 현황 목록 반환")
-    void testGetCommentAbuseReport_givenNullLastPostUlidAndPath_willReturnReadModelList() {
+    @DisplayName("lastPostUlid와 lastPath 모두 null일 때 getCommentAbuseReport로 댓글 신고 현황 응답 반환")
+    void testGetCommentAbuseReport_givenNullLastPostUlidAndPath_willReturnResponse() {
         // given
         given(reportDashboardRepository.getCommentAbuseReports(any(), any(), any())).willReturn(testCommentAbuseReportDashboardReadModelList);
 
         // when
-        List<CommentAbuseReportDashboardReadModel> readModels =
+        CommentAbuseReportDashboardResponse response =
                 memberAdminController.getCommentAbuseReport(new CommentAbuseReportGetRecord(AbuseReportStatus.UNCHECKED, null, null, TEST_REPORT_SIZE));
 
         // then
         verify(reportDashboardRepository, times(1)).getCommentAbuseReports(any(), any(), any());
-        assertThat(readModels).isEqualTo(testCommentAbuseReportDashboardReadModelList);
+        assertThat(response).isEqualTo(testCommentAbuseReportDashboardResponseWithFalseHasNext);
+    }
+
+    @Test
+    @DisplayName("페이지 크기보다 더 많은 데이터가 있을 때 getCommentAbuseReport로 hasNext가 true인 응답 반환")
+    void testGetCommentAbuseReport_givenMoreItemsThanPageSize_willReturnResponseWithTrueHasNext() {
+        // given
+        given(reportDashboardRepository.getCommentAbuseReports(any(), any(), any()))
+                .willReturn(List.of(testCommentAbuseReportDashboardReadModel, testCommentAbuseReportDashboardReadModel));
+
+        // when
+        CommentAbuseReportDashboardResponse response =
+                memberAdminController.getCommentAbuseReport(new CommentAbuseReportGetRecord(AbuseReportStatus.UNCHECKED, null, null, 1));
+
+        // then
+        verify(reportDashboardRepository, times(1)).getCommentAbuseReports(any(), any(), any());
+        assertThat(response).isEqualTo(testCommentAbuseReportDashboardResponseWithTrueHasNext);
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberAdminControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberAdminControllerTest.java
@@ -104,6 +104,21 @@ class MemberAdminControllerTest {
     }
 
     @Test
+    @DisplayName("조회된 읽기 모델이 비어 있을 때 getProposalOrBug로 건의 및 버그 제보 현황 응답 반환")
+    void testGetProposalOrBug_givenEmptyReadModel_willReturnResponse() {
+        // given
+        given(reportDashboardRepository.getProposalOrBugReports(any(), any(), any())).willReturn(List.of());
+
+        // when
+        ProposalOrBugReportDashboardResponse response =
+                memberAdminController.getProposalOrBug(new ProposalOrBugReportGetRecord(ProposalOrBugReportStatus.CHECKED, null, TEST_REPORT_SIZE));
+
+        // then
+        verify(reportDashboardRepository, times(1)).getProposalOrBugReports(any(), any(), any());
+        assertThat(response).isEqualTo(ProposalOrBugReportDashboardResponse.of(List.of(), null, false));
+    }
+
+    @Test
     @DisplayName("페이지 크기보다 더 많은 데이터가 있을 때 getProposalOrBug로 hasNext가 true인 응답 반환")
     void testGetProposalOrBug_givenMoreItemsThanPageSize_willReturnResponseWithTrueHasNext() {
         // given
@@ -206,6 +221,21 @@ class MemberAdminControllerTest {
         // then
         verify(reportDashboardRepository, times(1)).getPostAbuseReports(any(), any(), any());
         assertThat(response).isEqualTo(testPostAbuseReportDashboardResponseWithFalseHasNext);
+    }
+
+    @Test
+    @DisplayName("조회된 읽기 모델이 비어 있을 때 getPostAbuseReport로 게시글 신고 현황 응답 반환")
+    void testGetPostAbuseReport_givenEmptyReadModel_willReturnResponse() {
+        // given
+        given(reportDashboardRepository.getPostAbuseReports(any(), any(), any())).willReturn(List.of());
+
+        // when
+        PostAbuseReportDashboardResponse response =
+                memberAdminController.getPostAbuseReport(new PostAbuseReportGetRecord(AbuseReportStatus.UNCHECKED, null, TEST_REPORT_SIZE));
+
+        // then
+        verify(reportDashboardRepository, times(1)).getPostAbuseReports(any(), any(), any());
+        assertThat(response).isEqualTo(PostAbuseReportDashboardResponse.of(List.of(), null, false));
     }
 
     @Test
@@ -366,6 +396,21 @@ class MemberAdminControllerTest {
         // then
         verify(reportDashboardRepository, times(1)).getCommentAbuseReports(any(), any(), any());
         assertThat(response).isEqualTo(testCommentAbuseReportDashboardResponseWithFalseHasNext);
+    }
+
+    @Test
+    @DisplayName("조회된 읽기 모델이 비어 있을 때 getCommentAbuseReport로 댓글 신고 현황 응답 반환")
+    void testGetCommentAbuseReport_givenEmptyReadModel_willReturnResponse() {
+        // given
+        given(reportDashboardRepository.getCommentAbuseReports(any(), any(), any())).willReturn(List.of());
+
+        // when
+        CommentAbuseReportDashboardResponse response =
+                memberAdminController.getCommentAbuseReport(new CommentAbuseReportGetRecord(AbuseReportStatus.UNCHECKED, null, null, TEST_REPORT_SIZE));
+
+        // then
+        verify(reportDashboardRepository, times(1)).getCommentAbuseReports(any(), any(), any());
+        assertThat(response).isEqualTo(CommentAbuseReportDashboardResponse.of(List.of(), null, null, false));
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberAdminControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberAdminControllerTest.java
@@ -4,7 +4,9 @@ import kr.modusplant.domains.member.adapter.helper.MemberValidationHelper;
 import kr.modusplant.domains.member.domain.enums.AbuseReportStatus;
 import kr.modusplant.domains.member.domain.enums.ProposalOrBugReportStatus;
 import kr.modusplant.domains.member.domain.event.CommentAbuseReportApproveEvent;
+import kr.modusplant.domains.member.domain.event.CommentAbuseReportDismissEvent;
 import kr.modusplant.domains.member.domain.event.PostAbuseReportApproveEvent;
+import kr.modusplant.domains.member.domain.event.PostAbuseReportDismissEvent;
 import kr.modusplant.domains.member.usecase.model.read.CommentAbuseReportDashboardReadModel;
 import kr.modusplant.domains.member.usecase.model.read.PostAbuseReportDashboardReadModel;
 import kr.modusplant.domains.member.usecase.model.read.ProposalOrBugReportDashboardReadModel;
@@ -292,12 +294,14 @@ class MemberAdminControllerTest {
         willDoNothing().given(memberValidationHelper).validateIfActivitySubjectPostExists(any());
         given(reportDashboardRepository.isDismissedInPostAbuseReportDashboard(any())).willReturn(false);
         given(reportDashboardRepository.dismissPostAbuseReport(any())).willReturn(testPostAbuseReportDashboardReadModel);
+        willDoNothing().given(applicationEventPublisher).publishEvent(any(PostAbuseReportDismissEvent.class));
 
         // when
         PostAbuseReportDashboardReadModel readModel = memberAdminController.dismissPostAbuse(testPostAbuseReportDismissRecord);
 
         // then
         verify(reportDashboardRepository, times(1)).dismissPostAbuseReport(any());
+        verify(applicationEventPublisher, times(1)).publishEvent(any(PostAbuseReportDismissEvent.class));
         assertThat(readModel).isEqualTo(testPostAbuseReportDashboardReadModel);
     }
 
@@ -467,12 +471,14 @@ class MemberAdminControllerTest {
         willDoNothing().given(memberValidationHelper).validateIfActivitySubjectCommentExists(any());
         given(reportDashboardRepository.isDismissedInCommentAbuseReportDashboard(any())).willReturn(false);
         given(reportDashboardRepository.dismissCommentAbuseReport(any())).willReturn(testCommentAbuseReportDashboardReadModel);
+        willDoNothing().given(applicationEventPublisher).publishEvent(any(CommentAbuseReportDismissEvent.class));
 
         // when
         CommentAbuseReportDashboardReadModel readModel = memberAdminController.dismissCommentAbuse(testCommentAbuseReportDismissRecord);
 
         // then
         verify(reportDashboardRepository, times(1)).dismissCommentAbuseReport(any());
+        verify(applicationEventPublisher, times(1)).publishEvent(any(CommentAbuseReportDismissEvent.class));
         assertThat(readModel).isEqualTo(testCommentAbuseReportDashboardReadModel);
     }
 

--- a/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberAdminControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberAdminControllerTest.java
@@ -171,6 +171,7 @@ class MemberAdminControllerTest {
     void testRemoveProposalOrBug_givenValidRecord_willRemoveProposalOrBugReport() {
         // given
         given(reportRepository.isIdExistInProposalOrBugReport(testReportId)).willReturn(true);
+        given(reportRepository.isUncheckedInProposalOrBugReport(testReportId)).willReturn(false);
         willDoNothing().given(reportRepository).removeProposalOrBugReport(any());
 
         // when
@@ -191,6 +192,20 @@ class MemberAdminControllerTest {
 
         // then
         verify(reportRepository, never()).removeProposalOrBugReport(any());
+    }
+
+    @Test
+    @DisplayName("보고서가 존재하고 확인되지 않았을 때 removeProposalOrBug로 건의 및 버그 제보 제거")
+    void testRemoveProposalOrBug_givenNotCheckedReportId_willThrowException() {
+        // given
+        given(reportRepository.isIdExistInProposalOrBugReport(testReportId)).willReturn(true);
+        given(reportRepository.isUncheckedInProposalOrBugReport(testReportId)).willReturn(true);
+
+        // when
+        ExistsValueException existsValueException = assertThrows(ExistsValueException.class, () -> memberAdminController.removeProposalOrBug(testProposalOrBugReportRemoveRecord));
+
+        // then
+        assertThat(existsValueException.getErrorCode()).isEqualTo(NOT_FOUND_PROPOSAL_OR_BUG_REPORT_CHECKED);
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/common/util/domain/event/CommentAbuseReportApproveEventTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/domain/event/CommentAbuseReportApproveEventTestUtils.java
@@ -2,10 +2,10 @@ package kr.modusplant.domains.member.common.util.domain.event;
 
 import kr.modusplant.domains.member.domain.event.CommentAbuseReportApproveEvent;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentAbuseReportApproveEventTestUtils {
     CommentAbuseReportApproveEvent testCommentAbuseReportApproveEvent =
-            CommentAbuseReportApproveEvent.create(TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+            CommentAbuseReportApproveEvent.create(TEST_POST_ULID, TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/domain/event/CommentAbuseReportDismissEventTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/domain/event/CommentAbuseReportDismissEventTestUtils.java
@@ -1,0 +1,11 @@
+package kr.modusplant.domains.member.common.util.domain.event;
+
+import kr.modusplant.domains.member.domain.event.CommentAbuseReportDismissEvent;
+
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
+import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
+
+public interface CommentAbuseReportDismissEventTestUtils {
+    CommentAbuseReportDismissEvent testCommentAbuseReportDismissEvent =
+            CommentAbuseReportDismissEvent.create(TEST_POST_ULID, TEST_COMMENT_PATH);
+}

--- a/src/test/java/kr/modusplant/domains/member/common/util/domain/event/CommentAbuseReportEventTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/domain/event/CommentAbuseReportEventTestUtils.java
@@ -2,10 +2,10 @@ package kr.modusplant.domains.member.common.util.domain.event;
 
 import kr.modusplant.domains.member.domain.event.CommentAbuseReportEvent;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_CREATED_AT;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentAbuseReportEventTestUtils {
-    CommentAbuseReportEvent testCommentAbuseReportEvent = CommentAbuseReportEvent.create(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, TEST_POST_CREATED_AT);
+    CommentAbuseReportEvent testCommentAbuseReportEvent = CommentAbuseReportEvent.create(TEST_POST_ULID, TEST_COMMENT_PATH, TEST_POST_CREATED_AT);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/domain/event/PostAbuseReportDismissEventTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/domain/event/PostAbuseReportDismissEventTestUtils.java
@@ -1,0 +1,9 @@
+package kr.modusplant.domains.member.common.util.domain.event;
+
+import kr.modusplant.domains.member.domain.event.PostAbuseReportDismissEvent;
+
+import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
+
+public interface PostAbuseReportDismissEventTestUtils {
+    PostAbuseReportDismissEvent testPostAbuseReportDismissEvent = PostAbuseReportDismissEvent.create(TEST_POST_ULID);
+}

--- a/src/test/java/kr/modusplant/domains/member/common/util/domain/vo/ActivitySubjectCommentPathTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/domain/vo/ActivitySubjectCommentPathTestUtils.java
@@ -2,8 +2,8 @@ package kr.modusplant.domains.member.common.util.domain.vo;
 
 import kr.modusplant.domains.member.domain.vo.ActivitySubjectCommentPath;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 
 public interface ActivitySubjectCommentPathTestUtils {
-    ActivitySubjectCommentPath testActivitySubjectCommentPath = ActivitySubjectCommentPath.create(TEST_COMM_COMMENT_PATH);
+    ActivitySubjectCommentPath testActivitySubjectCommentPath = ActivitySubjectCommentPath.create(TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/framework/outbound/jooq/record/ActivitySubjectCommentIdRecordTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/framework/outbound/jooq/record/ActivitySubjectCommentIdRecordTestUtils.java
@@ -2,9 +2,9 @@ package kr.modusplant.domains.member.common.util.framework.outbound.jooq.record;
 
 import kr.modusplant.domains.member.framework.outbound.jooq.record.ActivitySubjectCommentIdRecord;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface ActivitySubjectCommentIdRecordTestUtils {
-    ActivitySubjectCommentIdRecord testActivitySubjectCommentIdRecord = new ActivitySubjectCommentIdRecord(TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+    ActivitySubjectCommentIdRecord testActivitySubjectCommentIdRecord = new ActivitySubjectCommentIdRecord(TEST_POST_ULID, TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/framework/outbound/jpa/entity/CommentAbuseReportDashboardEntityTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/framework/outbound/jpa/entity/CommentAbuseReportDashboardEntityTestUtils.java
@@ -4,7 +4,7 @@ import kr.modusplant.domains.member.domain.enums.AbuseReportStatus;
 import kr.modusplant.domains.member.framework.outbound.jpa.entity.CommentAbuseReportDashboardEntity;
 import kr.modusplant.domains.member.framework.outbound.jpa.entity.CommentAbuseReportDashboardEntity.CommentAbuseReportDashboardEntityBuilder;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.ReportConstant.*;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
@@ -12,7 +12,7 @@ public interface CommentAbuseReportDashboardEntityTestUtils {
     default CommentAbuseReportDashboardEntityBuilder createCommentAbuseReportDashboardUncheckedEntityBuilder() {
         return CommentAbuseReportDashboardEntity.builder()
                 .postUlid(TEST_POST_ULID)
-                .path(TEST_COMM_COMMENT_PATH)
+                .path(TEST_COMMENT_PATH)
                 .status(AbuseReportStatus.UNCHECKED)
                 .firstReportedAt(TEST_REPORT_CREATED_AT)
                 .lastReportedAt(TEST_REPORT_CREATED_AT);
@@ -21,7 +21,7 @@ public interface CommentAbuseReportDashboardEntityTestUtils {
     default CommentAbuseReportDashboardEntityBuilder createCommentAbuseReportDashboardDismissedEntityBuilder() {
         return CommentAbuseReportDashboardEntity.builder()
                 .postUlid(TEST_POST_ULID)
-                .path(TEST_COMM_COMMENT_PATH)
+                .path(TEST_COMMENT_PATH)
                 .status(AbuseReportStatus.DISMISSED)
                 .firstReportedAt(TEST_REPORT_CREATED_AT)
                 .lastReportedAt(TEST_REPORT_DISMISSED_AT);
@@ -30,7 +30,7 @@ public interface CommentAbuseReportDashboardEntityTestUtils {
     default CommentAbuseReportDashboardEntityBuilder createCommentAbuseReportDashboardBlindedEntityBuilder() {
         return CommentAbuseReportDashboardEntity.builder()
                 .postUlid(TEST_POST_ULID)
-                .path(TEST_COMM_COMMENT_PATH)
+                .path(TEST_COMMENT_PATH)
                 .status(AbuseReportStatus.BLINDED)
                 .firstReportedAt(TEST_REPORT_CREATED_AT)
                 .lastReportedAt(TEST_REPORT_BLINDED_AT);

--- a/src/test/java/kr/modusplant/domains/member/common/util/framework/outbound/jpa/entity/CommentLikeEntityTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/framework/outbound/jpa/entity/CommentLikeEntityTestUtils.java
@@ -3,12 +3,12 @@ package kr.modusplant.domains.member.common.util.framework.outbound.jpa.entity;
 import kr.modusplant.domains.comment.common.util.framework.outbound.persistence.jpa.entity.CommentEntityTestUtils;
 import kr.modusplant.domains.member.framework.outbound.jpa.entity.CommentLikeEntity;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.MemberConstant.MEMBER_BASIC_USER_UUID;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentLikeEntityTestUtils extends CommentEntityTestUtils, MemberEntityTestUtils {
     default CommentLikeEntity createCommentLikeEntity() {
-        return CommentLikeEntity.of(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
+        return CommentLikeEntity.of(TEST_POST_ULID, TEST_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
     }
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/model/read/CommentAbuseReportDashboardReadModelTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/model/read/CommentAbuseReportDashboardReadModelTestUtils.java
@@ -20,6 +20,7 @@ public interface CommentAbuseReportDashboardReadModelTestUtils {
                     TEST_COMMENT_CONTENT,
                     TEST_REPORT_SIZE,
                     AbuseReportStatus.UNCHECKED.name(),
+                    AbuseReportStatus.UNCHECKED.getValue(),
                     TEST_REPORT_CREATED_AT,
                     TEST_REPORT_CREATED_AT,
                     TEST_REPORT_CREATED_AT,

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/model/read/CommentAbuseReportDashboardReadModelTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/model/read/CommentAbuseReportDashboardReadModelTestUtils.java
@@ -5,8 +5,8 @@ import kr.modusplant.domains.member.usecase.model.read.CommentAbuseReportDashboa
 
 import java.util.List;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_CONTENT;
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_CONTENT;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.MemberConstant.MEMBER_BASIC_USER_NICKNAME;
 import static kr.modusplant.domains.member.common.constant.ReportConstant.TEST_REPORT_CREATED_AT;
 import static kr.modusplant.domains.member.common.constant.ReportConstant.TEST_REPORT_SIZE;
@@ -16,8 +16,8 @@ public interface CommentAbuseReportDashboardReadModelTestUtils {
     CommentAbuseReportDashboardReadModel testCommentAbuseReportDashboardReadModel =
             new CommentAbuseReportDashboardReadModel(
                     TEST_POST_ULID,
-                    TEST_COMM_COMMENT_PATH,
-                    TEST_COMM_COMMENT_CONTENT,
+                    TEST_COMMENT_PATH,
+                    TEST_COMMENT_CONTENT,
                     TEST_REPORT_SIZE,
                     AbuseReportStatus.UNCHECKED.name(),
                     TEST_REPORT_CREATED_AT,

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/model/read/PostAbuseReportDashboardReadModelTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/model/read/PostAbuseReportDashboardReadModelTestUtils.java
@@ -17,6 +17,7 @@ public interface PostAbuseReportDashboardReadModelTestUtils {
                     TEST_POST_CONTENT_JSON_NODE,
                     TEST_REPORT_SIZE,
                     AbuseReportStatus.UNCHECKED.name(),
+                    AbuseReportStatus.UNCHECKED.getValue(),
                     TEST_POST_CREATED_AT,
                     TEST_POST_UPDATED_AT,
                     TEST_POST_UPDATED_AT,

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/model/read/ProposalOrBugReportDashboardReadModelTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/model/read/ProposalOrBugReportDashboardReadModelTestUtils.java
@@ -19,7 +19,8 @@ public interface ProposalOrBugReportDashboardReadModelTestUtils {
                     TEST_REPORT_CREATED_AT,
                     TEST_REPORT_CHECKED_AT,
                     MEMBER_BASIC_USER_NICKNAME,
-                    ProposalOrBugReportStatus.CHECKED.name());
+                    ProposalOrBugReportStatus.CHECKED.name(),
+                    ProposalOrBugReportStatus.CHECKED.getValue());
     List<ProposalOrBugReportDashboardReadModel> testProposalOrBugReportDashboardCheckedReadModelList =
             List.of(testProposalOrBugReportDashboardCheckedReadModel);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/CommentAbuseReportApproveRecordTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/CommentAbuseReportApproveRecordTestUtils.java
@@ -2,10 +2,10 @@ package kr.modusplant.domains.member.common.util.usecase.record;
 
 import kr.modusplant.domains.member.usecase.record.CommentAbuseReportApproveRecord;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentAbuseReportApproveRecordTestUtils {
     CommentAbuseReportApproveRecord testCommentAbuseReportApproveRecord =
-            new CommentAbuseReportApproveRecord(TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+            new CommentAbuseReportApproveRecord(TEST_POST_ULID, TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/CommentAbuseReportDismissRecordTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/CommentAbuseReportDismissRecordTestUtils.java
@@ -2,10 +2,10 @@ package kr.modusplant.domains.member.common.util.usecase.record;
 
 import kr.modusplant.domains.member.usecase.record.CommentAbuseReportDismissRecord;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentAbuseReportDismissRecordTestUtils {
     CommentAbuseReportDismissRecord testCommentAbuseReportDismissRecord =
-            new CommentAbuseReportDismissRecord(TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+            new CommentAbuseReportDismissRecord(TEST_POST_ULID, TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/CommentAbuseReportGetRecordTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/CommentAbuseReportGetRecordTestUtils.java
@@ -3,11 +3,11 @@ package kr.modusplant.domains.member.common.util.usecase.record;
 import kr.modusplant.domains.member.domain.enums.AbuseReportStatus;
 import kr.modusplant.domains.member.usecase.record.CommentAbuseReportGetRecord;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.ReportConstant.TEST_REPORT_SIZE;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentAbuseReportGetRecordTestUtils {
     CommentAbuseReportGetRecord testCommentAbuseReportGetRecord =
-            new CommentAbuseReportGetRecord(AbuseReportStatus.UNCHECKED, TEST_POST_ULID, TEST_COMM_COMMENT_PATH, TEST_REPORT_SIZE);
+            new CommentAbuseReportGetRecord(AbuseReportStatus.UNCHECKED, TEST_POST_ULID, TEST_COMMENT_PATH, TEST_REPORT_SIZE);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/CommentAbuseReportRecordTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/CommentAbuseReportRecordTestUtils.java
@@ -2,10 +2,10 @@ package kr.modusplant.domains.member.common.util.usecase.record;
 
 import kr.modusplant.domains.member.usecase.record.CommentAbuseReportRecord;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.MemberConstant.MEMBER_BASIC_USER_UUID;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface CommentAbuseReportRecordTestUtils {
-    CommentAbuseReportRecord testCommentAbuseReportRecord = new CommentAbuseReportRecord(MEMBER_BASIC_USER_UUID, TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+    CommentAbuseReportRecord testCommentAbuseReportRecord = new CommentAbuseReportRecord(MEMBER_BASIC_USER_UUID, TEST_POST_ULID, TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/MemberCommentLikeRecordTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/MemberCommentLikeRecordTestUtils.java
@@ -2,10 +2,10 @@ package kr.modusplant.domains.member.common.util.usecase.record;
 
 import kr.modusplant.domains.member.usecase.record.MemberCommentLikeRecord;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.MemberConstant.MEMBER_BASIC_USER_UUID;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface MemberCommentLikeRecordTestUtils {
-    MemberCommentLikeRecord testMemberCommentLikeRecord = new MemberCommentLikeRecord(MEMBER_BASIC_USER_UUID, TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+    MemberCommentLikeRecord testMemberCommentLikeRecord = new MemberCommentLikeRecord(MEMBER_BASIC_USER_UUID, TEST_POST_ULID, TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/MemberCommentUnlikeRecordTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/record/MemberCommentUnlikeRecordTestUtils.java
@@ -2,10 +2,10 @@ package kr.modusplant.domains.member.common.util.usecase.record;
 
 import kr.modusplant.domains.member.usecase.record.MemberCommentUnlikeRecord;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.MemberConstant.MEMBER_BASIC_USER_UUID;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 
 public interface MemberCommentUnlikeRecordTestUtils {
-    MemberCommentUnlikeRecord testMemberCommentUnlikeRecord = new MemberCommentUnlikeRecord(MEMBER_BASIC_USER_UUID, TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+    MemberCommentUnlikeRecord testMemberCommentUnlikeRecord = new MemberCommentUnlikeRecord(MEMBER_BASIC_USER_UUID, TEST_POST_ULID, TEST_COMMENT_PATH);
 }

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/response/CommentAbuseDashboardResponseTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/response/CommentAbuseDashboardResponseTestUtils.java
@@ -1,0 +1,19 @@
+package kr.modusplant.domains.member.common.util.usecase.response;
+
+import kr.modusplant.domains.member.usecase.response.CommentAbuseReportDashboardResponse;
+
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
+import static kr.modusplant.domains.member.common.util.usecase.model.read.CommentAbuseReportDashboardReadModelTestUtils.testCommentAbuseReportDashboardReadModelList;
+import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
+
+public interface CommentAbuseDashboardResponseTestUtils {
+    CommentAbuseReportDashboardResponse testCommentAbuseReportDashboardResponseWithFalseHasNext =
+            CommentAbuseReportDashboardResponse.of(
+                    testCommentAbuseReportDashboardReadModelList,
+                    TEST_POST_ULID, TEST_COMMENT_PATH, false);
+
+    CommentAbuseReportDashboardResponse testCommentAbuseReportDashboardResponseWithTrueHasNext =
+            CommentAbuseReportDashboardResponse.of(
+                    testCommentAbuseReportDashboardReadModelList,
+                    TEST_POST_ULID, TEST_COMMENT_PATH, true);
+}

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/response/PostAbuseDashboardResponseTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/response/PostAbuseDashboardResponseTestUtils.java
@@ -1,0 +1,16 @@
+package kr.modusplant.domains.member.common.util.usecase.response;
+
+import kr.modusplant.domains.member.usecase.response.PostAbuseReportDashboardResponse;
+
+import static kr.modusplant.domains.member.common.util.usecase.model.read.PostAbuseReportDashboardReadModelTestUtils.testPostAbuseReportDashboardReadModelList;
+import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
+
+public interface PostAbuseDashboardResponseTestUtils {
+    PostAbuseReportDashboardResponse testPostAbuseReportDashboardResponseWithFalseHasNext =
+            PostAbuseReportDashboardResponse.of(
+                    testPostAbuseReportDashboardReadModelList, TEST_POST_ULID, false);
+
+    PostAbuseReportDashboardResponse testPostAbuseReportDashboardResponseWithTrueHasNext =
+            PostAbuseReportDashboardResponse.of(
+                    testPostAbuseReportDashboardReadModelList, TEST_POST_ULID, true);
+}

--- a/src/test/java/kr/modusplant/domains/member/common/util/usecase/response/ProposalOrBugReportDashboardResponseTestUtils.java
+++ b/src/test/java/kr/modusplant/domains/member/common/util/usecase/response/ProposalOrBugReportDashboardResponseTestUtils.java
@@ -1,0 +1,16 @@
+package kr.modusplant.domains.member.common.util.usecase.response;
+
+import kr.modusplant.domains.member.usecase.response.ProposalOrBugReportDashboardResponse;
+
+import static kr.modusplant.domains.member.common.constant.ReportConstant.TEST_REPORT_ULID;
+import static kr.modusplant.domains.member.common.util.usecase.model.read.ProposalOrBugReportDashboardReadModelTestUtils.testProposalOrBugReportDashboardCheckedReadModelList;
+
+public interface ProposalOrBugReportDashboardResponseTestUtils {
+    ProposalOrBugReportDashboardResponse testProposalOrBugReportDashboardResponseWithFalseHasNext =
+            ProposalOrBugReportDashboardResponse.of(
+                    testProposalOrBugReportDashboardCheckedReadModelList, TEST_REPORT_ULID, false);
+
+    ProposalOrBugReportDashboardResponse testProposalOrBugReportDashboardResponseWithTrueHasNext =
+            ProposalOrBugReportDashboardResponse.of(
+                    testProposalOrBugReportDashboardCheckedReadModelList, TEST_REPORT_ULID, true);
+}

--- a/src/test/java/kr/modusplant/domains/member/domain/event/CommentAbuseReportApproveEventTest.java
+++ b/src/test/java/kr/modusplant/domains/member/domain/event/CommentAbuseReportApproveEventTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,12 +21,12 @@ class CommentAbuseReportApproveEventTest {
         void testCreate_givenValidParameters_willReturnEvent() {
             // when
             CommentAbuseReportApproveEvent event =
-                    CommentAbuseReportApproveEvent.create(TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+                    CommentAbuseReportApproveEvent.create(TEST_POST_ULID, TEST_COMMENT_PATH);
 
             // then
             assertNotNull(event);
             assertEquals(TEST_POST_ULID, event.getPostUlid());
-            assertEquals(TEST_COMM_COMMENT_PATH, event.getPath());
+            assertEquals(TEST_COMMENT_PATH, event.getPath());
         }
 
         @Test
@@ -34,7 +34,7 @@ class CommentAbuseReportApproveEventTest {
         void testCreate_givenBlankPostUlid_willThrowException() {
             // given & when
             InvalidValueException exception = assertThrows(InvalidValueException.class, () ->
-                    CommentAbuseReportApproveEvent.create("", TEST_COMM_COMMENT_PATH));
+                    CommentAbuseReportApproveEvent.create("", TEST_COMMENT_PATH));
 
             // then
             assertThat(exception.getMessage()).contains("NOT_FOUND_COMMENT");

--- a/src/test/java/kr/modusplant/domains/member/domain/event/CommentAbuseReportDismissEventTest.java
+++ b/src/test/java/kr/modusplant/domains/member/domain/event/CommentAbuseReportDismissEventTest.java
@@ -6,14 +6,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
-import static kr.modusplant.domains.member.common.util.domain.event.CommentAbuseReportApproveEventTestUtils.testCommentAbuseReportApproveEvent;
+import static kr.modusplant.domains.member.common.util.domain.event.CommentAbuseReportDismissEventTestUtils.testCommentAbuseReportDismissEvent;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 import static kr.modusplant.shared.framework.jpa.exception.enums.EntityErrorCode.NOT_FOUND_COMMENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class CommentAbuseReportApproveEventTest {
+class CommentAbuseReportDismissEventTest {
 
     @Nested
     @DisplayName("create 테스트")
@@ -22,7 +22,7 @@ class CommentAbuseReportApproveEventTest {
         @Test
         @DisplayName("유효한 파라미터로 객체 생성 성공")
         void testCreate_givenValidParameters_willReturnEvent() {
-            assertNotNull(testCommentAbuseReportApproveEvent);
+            assertNotNull(testCommentAbuseReportDismissEvent);
         }
 
         @Test
@@ -30,7 +30,7 @@ class CommentAbuseReportApproveEventTest {
         void testCreate_givenBlankPostUlid_willThrowException() {
             // given & when
             InvalidValueException exception = assertThrows(InvalidValueException.class, () ->
-                    CommentAbuseReportApproveEvent.create("", TEST_COMMENT_PATH));
+                    CommentAbuseReportDismissEvent.create("", TEST_COMMENT_PATH));
 
             // then
             assertThat(exception.getErrorCode()).isEqualTo(NOT_FOUND_COMMENT);
@@ -41,7 +41,7 @@ class CommentAbuseReportApproveEventTest {
         void testCreate_givenBlankPath_willThrowException() {
             // given & when
             InvalidValueException exception = assertThrows(InvalidValueException.class, () ->
-                    CommentAbuseReportApproveEvent.create(TEST_POST_ULID, " "));
+                    CommentAbuseReportDismissEvent.create(TEST_POST_ULID, " "));
 
             // then
             assertThat(exception.getErrorCode()).isEqualTo(NOT_FOUND_COMMENT);

--- a/src/test/java/kr/modusplant/domains/member/domain/event/PostAbuseReportApproveEventTest.java
+++ b/src/test/java/kr/modusplant/domains/member/domain/event/PostAbuseReportApproveEventTest.java
@@ -1,0 +1,37 @@
+package kr.modusplant.domains.member.domain.event;
+
+import kr.modusplant.shared.exception.InvalidValueException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static kr.modusplant.domains.member.common.util.domain.event.PostAbuseReportApproveEventTestUtils.testPostAbuseReportApproveEvent;
+import static kr.modusplant.shared.framework.jpa.exception.enums.EntityErrorCode.NOT_FOUND_POST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PostAbuseReportApproveEventTest {
+
+    @Nested
+    @DisplayName("create 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 파라미터로 객체 생성 성공")
+        void testCreate_givenValidParameters_willReturnEvent() {
+            assertNotNull(testPostAbuseReportApproveEvent);
+        }
+
+        @Test
+        @DisplayName("postUlid가 비어 있을 때 오류 발생")
+        void testCreate_givenBlankPostUlid_willThrowException() {
+            // given & when
+            InvalidValueException exception = assertThrows(InvalidValueException.class, () ->
+                    PostAbuseReportApproveEvent.create(""));
+
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo(NOT_FOUND_POST);
+        }
+    }
+}

--- a/src/test/java/kr/modusplant/domains/member/domain/event/PostAbuseReportDismissEventTest.java
+++ b/src/test/java/kr/modusplant/domains/member/domain/event/PostAbuseReportDismissEventTest.java
@@ -1,0 +1,37 @@
+package kr.modusplant.domains.member.domain.event;
+
+import kr.modusplant.shared.exception.InvalidValueException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static kr.modusplant.domains.member.common.util.domain.event.PostAbuseReportDismissEventTestUtils.testPostAbuseReportDismissEvent;
+import static kr.modusplant.shared.framework.jpa.exception.enums.EntityErrorCode.NOT_FOUND_POST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PostAbuseReportDismissEventTest {
+
+    @Nested
+    @DisplayName("create 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("유효한 파라미터로 객체 생성 성공")
+        void testCreate_givenValidParameters_willReturnEvent() {
+            assertNotNull(testPostAbuseReportDismissEvent);
+        }
+
+        @Test
+        @DisplayName("postUlid가 비어 있을 때 오류 발생")
+        void testCreate_givenBlankPostUlid_willThrowException() {
+            // given & when
+            InvalidValueException exception = assertThrows(InvalidValueException.class, () ->
+                    PostAbuseReportDismissEvent.create(""));
+
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo(NOT_FOUND_POST);
+        }
+    }
+}

--- a/src/test/java/kr/modusplant/domains/member/domain/vo/ActivitySubjectCommentIdTest.java
+++ b/src/test/java/kr/modusplant/domains/member/domain/vo/ActivitySubjectCommentIdTest.java
@@ -5,7 +5,7 @@ import kr.modusplant.shared.exception.EmptyValueException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.util.domain.vo.ActivitySubjectCommentIdTestUtils.testActivitySubjectCommentId;
 import static kr.modusplant.domains.member.common.util.domain.vo.ActivitySubjectCommentPathTestUtils.testActivitySubjectCommentPath;
 import static kr.modusplant.domains.member.common.util.domain.vo.ActivitySubjectPostIdTestUtils.testActivitySubjectPostId;
@@ -54,7 +54,7 @@ class ActivitySubjectCommentIdTest {
     @Test
     @DisplayName("다른 프로퍼티를 갖는 인스턴스에 대한 equals 호출")
     void testEquals_givenObjectContainingDifferentProperty_willReturnFalse() {
-        assertNotEquals(testActivitySubjectCommentId, ActivitySubjectCommentId.create(testActivitySubjectPostId, ActivitySubjectCommentPath.create(TEST_COMM_COMMENT_PATH + "1")));
+        assertNotEquals(testActivitySubjectCommentId, ActivitySubjectCommentId.create(testActivitySubjectPostId, ActivitySubjectCommentPath.create(TEST_COMMENT_PATH + "1")));
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/domain/vo/ActivitySubjectCommentPathTest.java
+++ b/src/test/java/kr/modusplant/domains/member/domain/vo/ActivitySubjectCommentPathTest.java
@@ -6,7 +6,7 @@ import kr.modusplant.shared.exception.InvalidValueException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.util.domain.vo.ActivitySubjectCommentPathTestUtils.testActivitySubjectCommentPath;
 import static kr.modusplant.domains.member.common.util.domain.vo.MemberStatusTestUtils.testMemberActiveStatus;
 import static kr.modusplant.domains.member.domain.exception.enums.MemberErrorCode.INVALID_ACTIVITY_SUBJECT_COMMENT_PATH;
@@ -17,7 +17,7 @@ class ActivitySubjectCommentPathTest {
     @Test
     @DisplayName("create으로 대상 댓글 아이디 반환")
     void testCreate_givenValidValue_willReturnActivitySubjectCommentPath() {
-        assertNotNull(ActivitySubjectCommentPath.create(TEST_COMM_COMMENT_PATH).getValue());
+        assertNotNull(ActivitySubjectCommentPath.create(TEST_COMMENT_PATH).getValue());
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberAdminRestControllerTest.java
@@ -6,6 +6,9 @@ import kr.modusplant.domains.member.domain.enums.ProposalOrBugReportStatus;
 import kr.modusplant.domains.member.usecase.model.read.CommentAbuseReportDashboardReadModel;
 import kr.modusplant.domains.member.usecase.model.read.PostAbuseReportDashboardReadModel;
 import kr.modusplant.domains.member.usecase.model.read.ProposalOrBugReportDashboardReadModel;
+import kr.modusplant.domains.member.usecase.response.CommentAbuseReportDashboardResponse;
+import kr.modusplant.domains.member.usecase.response.PostAbuseReportDashboardResponse;
+import kr.modusplant.domains.member.usecase.response.ProposalOrBugReportDashboardResponse;
 import kr.modusplant.shared.framework.jackson.holder.ObjectMapperHolder;
 import kr.modusplant.shared.framework.jackson.http.response.DataResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -14,18 +17,14 @@ import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.util.List;
 import java.util.Objects;
 
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.ReportConstant.TEST_REPORT_SIZE;
 import static kr.modusplant.domains.member.common.constant.ReportConstant.TEST_REPORT_ULID;
-import static kr.modusplant.domains.member.common.util.usecase.model.read.PostAbuseReportDashboardReadModelTestUtils.testPostAbuseReportDashboardReadModel;
-import static kr.modusplant.domains.member.common.util.usecase.model.read.PostAbuseReportDashboardReadModelTestUtils.testPostAbuseReportDashboardReadModelList;
-import static kr.modusplant.domains.member.common.util.usecase.model.read.ProposalOrBugReportDashboardReadModelTestUtils.testProposalOrBugReportDashboardCheckedReadModel;
-import static kr.modusplant.domains.member.common.util.usecase.model.read.ProposalOrBugReportDashboardReadModelTestUtils.testProposalOrBugReportDashboardCheckedReadModelList;
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.util.usecase.model.read.CommentAbuseReportDashboardReadModelTestUtils.testCommentAbuseReportDashboardReadModel;
-import static kr.modusplant.domains.member.common.util.usecase.model.read.CommentAbuseReportDashboardReadModelTestUtils.testCommentAbuseReportDashboardReadModelList;
+import static kr.modusplant.domains.member.common.util.usecase.model.read.PostAbuseReportDashboardReadModelTestUtils.testPostAbuseReportDashboardReadModel;
+import static kr.modusplant.domains.member.common.util.usecase.model.read.ProposalOrBugReportDashboardReadModelTestUtils.testProposalOrBugReportDashboardCheckedReadModel;
 import static kr.modusplant.domains.member.common.util.usecase.record.CommentAbuseReportApproveRecordTestUtils.testCommentAbuseReportApproveRecord;
 import static kr.modusplant.domains.member.common.util.usecase.record.CommentAbuseReportDismissRecordTestUtils.testCommentAbuseReportDismissRecord;
 import static kr.modusplant.domains.member.common.util.usecase.record.CommentAbuseReportGetRecordTestUtils.testCommentAbuseReportGetRecord;
@@ -35,6 +34,9 @@ import static kr.modusplant.domains.member.common.util.usecase.record.PostAbuseR
 import static kr.modusplant.domains.member.common.util.usecase.record.ProposalOrBugReportCheckRecordTestUtils.testProposalOrBugReportCheckRecord;
 import static kr.modusplant.domains.member.common.util.usecase.record.ProposalOrBugReportRecordGetTestUtils.testProposalOrBugReportGetRecord;
 import static kr.modusplant.domains.member.common.util.usecase.record.ProposalOrBugReportRemoveRecordTestUtils.testProposalOrBugReportRemoveRecord;
+import static kr.modusplant.domains.member.common.util.usecase.response.CommentAbuseDashboardResponseTestUtils.testCommentAbuseReportDashboardResponseWithFalseHasNext;
+import static kr.modusplant.domains.member.common.util.usecase.response.PostAbuseDashboardResponseTestUtils.testPostAbuseReportDashboardResponseWithFalseHasNext;
+import static kr.modusplant.domains.member.common.util.usecase.response.ProposalOrBugReportDashboardResponseTestUtils.testProposalOrBugReportDashboardResponseWithFalseHasNext;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 import static kr.modusplant.infrastructure.config.jackson.JacksonConfig.objectMapper;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,14 +53,14 @@ class MemberAdminRestControllerTest {
     @DisplayName("getProposalOrBugReport로 응답 반환")
     void testGetProposalOrBugReport_givenValidRequest_willReturnResponse() {
         // given
-        given(memberAdminController.getProposalOrBug(testProposalOrBugReportGetRecord)).willReturn(testProposalOrBugReportDashboardCheckedReadModelList);
+        given(memberAdminController.getProposalOrBug(testProposalOrBugReportGetRecord)).willReturn(testProposalOrBugReportDashboardResponseWithFalseHasNext);
 
         // when
-        ResponseEntity<DataResponse<List<ProposalOrBugReportDashboardReadModel>>> responseEntity = memberAdminRestController.getProposalOrBugReport(ProposalOrBugReportStatus.CHECKED, TEST_REPORT_ULID, TEST_REPORT_SIZE);
+        ResponseEntity<DataResponse<ProposalOrBugReportDashboardResponse>> responseEntity = memberAdminRestController.getProposalOrBugReport(ProposalOrBugReportStatus.CHECKED, TEST_REPORT_ULID, TEST_REPORT_SIZE);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(Objects.requireNonNull(responseEntity.getBody()).toString()).isEqualTo(DataResponse.ok(testProposalOrBugReportDashboardCheckedReadModelList).toString());
+        assertThat(Objects.requireNonNull(responseEntity.getBody()).toString()).isEqualTo(DataResponse.ok(testProposalOrBugReportDashboardResponseWithFalseHasNext).toString());
     }
 
     @Test
@@ -93,15 +95,15 @@ class MemberAdminRestControllerTest {
     @DisplayName("getPostAbuseReport로 응답 반환")
     void testGetPostAbuseReport_givenValidRequest_willReturnResponse() {
         // given
-        given(memberAdminController.getPostAbuseReport(testPostAbuseReportGetRecord)).willReturn(testPostAbuseReportDashboardReadModelList);
+        given(memberAdminController.getPostAbuseReport(testPostAbuseReportGetRecord)).willReturn(testPostAbuseReportDashboardResponseWithFalseHasNext);
 
         // when
-        ResponseEntity<DataResponse<List<PostAbuseReportDashboardReadModel>>> responseEntity =
+        ResponseEntity<DataResponse<PostAbuseReportDashboardResponse>> responseEntity =
                 memberAdminRestController.getPostAbuseReport(AbuseReportStatus.UNCHECKED, TEST_POST_ULID, TEST_REPORT_SIZE);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(Objects.requireNonNull(responseEntity.getBody()).toString()).isEqualTo(DataResponse.ok(testPostAbuseReportDashboardReadModelList).toString());
+        assertThat(Objects.requireNonNull(responseEntity.getBody()).toString()).isEqualTo(DataResponse.ok(testPostAbuseReportDashboardResponseWithFalseHasNext).toString());
     }
 
     @Test
@@ -141,16 +143,16 @@ class MemberAdminRestControllerTest {
     void testGetCommentAbuseReport_givenValidRequest_willReturnResponse() {
         // given
         given(memberAdminController.getCommentAbuseReport(testCommentAbuseReportGetRecord))
-                .willReturn(testCommentAbuseReportDashboardReadModelList);
+                .willReturn(testCommentAbuseReportDashboardResponseWithFalseHasNext);
 
         // when
-        ResponseEntity<DataResponse<List<CommentAbuseReportDashboardReadModel>>> responseEntity =
-                memberAdminRestController.getCommentAbuseReport(AbuseReportStatus.UNCHECKED, TEST_POST_ULID, TEST_COMM_COMMENT_PATH, TEST_REPORT_SIZE);
+        ResponseEntity<DataResponse<CommentAbuseReportDashboardResponse>> responseEntity =
+                memberAdminRestController.getCommentAbuseReport(AbuseReportStatus.UNCHECKED, TEST_POST_ULID, TEST_COMMENT_PATH, TEST_REPORT_SIZE);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(Objects.requireNonNull(responseEntity.getBody()).toString())
-                .isEqualTo(DataResponse.ok(testCommentAbuseReportDashboardReadModelList).toString());
+                .isEqualTo(DataResponse.ok(testCommentAbuseReportDashboardResponseWithFalseHasNext).toString());
     }
 
     @Test
@@ -162,7 +164,7 @@ class MemberAdminRestControllerTest {
 
         // when
         ResponseEntity<DataResponse<CommentAbuseReportDashboardReadModel>> responseEntity =
-                memberAdminRestController.dismissCommentAbuseReport(TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+                memberAdminRestController.dismissCommentAbuseReport(TEST_POST_ULID, TEST_COMMENT_PATH);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -179,7 +181,7 @@ class MemberAdminRestControllerTest {
 
         // when
         ResponseEntity<DataResponse<CommentAbuseReportDashboardReadModel>> responseEntity =
-                memberAdminRestController.approveCommentAbuseReport(TEST_POST_ULID, TEST_COMM_COMMENT_PATH);
+                memberAdminRestController.approveCommentAbuseReport(TEST_POST_ULID, TEST_COMMENT_PATH);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberRestControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/inbound/web/rest/MemberRestControllerTest.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import static kr.modusplant.domains.account.identity.common.constant.MemberAuthConstant.MEMBER_AUTH_BASIC_USER_AUTHORIZATION;
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.constant.MemberConstant.MEMBER_BASIC_USER_NICKNAME;
 import static kr.modusplant.domains.member.common.constant.MemberConstant.MEMBER_BASIC_USER_UUID;
 import static kr.modusplant.domains.member.common.constant.MemberProfileConstant.MEMBER_PROFILE_BASIC_USER_IMAGE;
@@ -215,7 +215,7 @@ class MemberRestControllerTest implements MemberTestUtils {
         willDoNothing().given(memberController).likeComment(testMemberCommentLikeRecord);
 
         // when
-        ResponseEntity<DataResponse<Void>> responseEntity = memberRestController.likeCommunicationComment(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
+        ResponseEntity<DataResponse<Void>> responseEntity = memberRestController.likeCommunicationComment(TEST_POST_ULID, TEST_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -229,7 +229,7 @@ class MemberRestControllerTest implements MemberTestUtils {
         willDoNothing().given(memberController).unlikeComment(testMemberCommentUnlikeRecord);
 
         // when
-        ResponseEntity<DataResponse<Void>> responseEntity = memberRestController.unlikeCommunicationComment(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
+        ResponseEntity<DataResponse<Void>> responseEntity = memberRestController.unlikeCommunicationComment(TEST_POST_ULID, TEST_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -279,7 +279,7 @@ class MemberRestControllerTest implements MemberTestUtils {
     @DisplayName("댓글 ID를 포함하지 않는 요청으로 reportCommentAbuse로 응답 반환")
     void testReportCommentAbuse_givenValidRequestWithoutCommentId_willReturnResponse() {
         // given & when
-        ResponseEntity<DataResponse<Void>> responseEntity = memberRestController.reportCommentAbuse(TEST_COMM_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
+        ResponseEntity<DataResponse<Void>> responseEntity = memberRestController.reportCommentAbuse(TEST_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
@@ -293,7 +293,7 @@ class MemberRestControllerTest implements MemberTestUtils {
         willDoNothing().given(memberController).reportCommentAbuse(testCommentAbuseReportRecord);
 
         // when
-        ResponseEntity<DataResponse<Void>> responseEntity = memberRestController.reportCommentAbuse(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
+        ResponseEntity<DataResponse<Void>> responseEntity = memberRestController.reportCommentAbuse(TEST_POST_ULID, TEST_COMMENT_PATH, MEMBER_BASIC_USER_UUID);
 
         // then
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/ReportDashboardRepositoryAdapterTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/ReportDashboardRepositoryAdapterTest.java
@@ -139,14 +139,14 @@ class ReportDashboardRepositoryAdapterTest implements PostAbuseReportEntityTestU
         // given
         PostAbuseReportDashboardEntity uncheckedEntity = createPostAbuseReportDashboardUncheckedEntityBuilder().build();
         given(postAbuseReportDashboardJpaRepository.findById(TEST_POST_ULID)).willReturn(Optional.of(uncheckedEntity));
-        given(postAbuseReportDashboardJpaRepository.save(any())).willReturn(uncheckedEntity);
+        given(postAbuseReportDashboardJpaRepository.saveAndFlush(any())).willReturn(uncheckedEntity);
         given(postAbuseReportDashboardJooqRepository.getReadModelByPostId(TEST_POST_ULID)).willReturn(testPostAbuseReportDashboardReadModel);
 
         // when
         PostAbuseReportDashboardReadModel readModel = reportDashboardRepositoryAdapter.dismissPostAbuseReport(ActivitySubjectPostId.create(TEST_POST_ULID));
 
         // then
-        verify(postAbuseReportDashboardJpaRepository, times(1)).save(any());
+        verify(postAbuseReportDashboardJpaRepository, times(1)).saveAndFlush(any());
         verify(postAbuseReportDashboardJooqRepository, times(1)).getReadModelByPostId(TEST_POST_ULID);
         assertThat(readModel).isEqualTo(testPostAbuseReportDashboardReadModel);
     }
@@ -172,14 +172,14 @@ class ReportDashboardRepositoryAdapterTest implements PostAbuseReportEntityTestU
         // given
         PostAbuseReportDashboardEntity uncheckedEntity = createPostAbuseReportDashboardUncheckedEntityBuilder().build();
         given(postAbuseReportDashboardJpaRepository.findById(TEST_POST_ULID)).willReturn(Optional.of(uncheckedEntity));
-        given(postAbuseReportDashboardJpaRepository.save(any())).willReturn(uncheckedEntity);
+        given(postAbuseReportDashboardJpaRepository.saveAndFlush(any())).willReturn(uncheckedEntity);
         given(postAbuseReportDashboardJooqRepository.getReadModelByPostId(TEST_POST_ULID)).willReturn(testPostAbuseReportDashboardReadModel);
 
         // when
         PostAbuseReportDashboardReadModel readModel = reportDashboardRepositoryAdapter.approvePostAbuseReport(testActivitySubjectPostId);
 
         // then
-        verify(postAbuseReportDashboardJpaRepository, times(1)).save(any());
+        verify(postAbuseReportDashboardJpaRepository, times(1)).saveAndFlush(any());
         verify(postAbuseReportDashboardJooqRepository, times(1)).getReadModelByPostId(TEST_POST_ULID);
         assertThat(readModel).isEqualTo(testPostAbuseReportDashboardReadModel);
     }

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/ReportDashboardRepositoryAdapterTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/ReportDashboardRepositoryAdapterTest.java
@@ -7,11 +7,11 @@ import kr.modusplant.domains.member.common.util.framework.outbound.jpa.entity.Po
 import kr.modusplant.domains.member.common.util.framework.outbound.jpa.entity.ProposalBugReportEntityTestUtils;
 import kr.modusplant.domains.member.domain.enums.AbuseReportStatus;
 import kr.modusplant.domains.member.domain.vo.ActivitySubjectPostId;
-import kr.modusplant.domains.member.framework.outbound.jpa.entity.PostAbuseReportDashboardEntity;
 import kr.modusplant.domains.member.domain.vo.ReportPageSize;
 import kr.modusplant.domains.member.framework.outbound.jooq.repository.CommentAbuseReportDashboardJooqRepository;
 import kr.modusplant.domains.member.framework.outbound.jooq.repository.PostAbuseReportDashboardJooqRepository;
 import kr.modusplant.domains.member.framework.outbound.jooq.repository.ProposalOrBugReportDashboardJooqRepository;
+import kr.modusplant.domains.member.framework.outbound.jpa.entity.PostAbuseReportDashboardEntity;
 import kr.modusplant.domains.member.framework.outbound.jpa.repository.CommentAbuseReportDashboardJpaRepository;
 import kr.modusplant.domains.member.framework.outbound.jpa.repository.PostAbuseReportDashboardJpaRepository;
 import kr.modusplant.domains.member.framework.outbound.jpa.repository.ProposalOrBugReportJpaRepository;
@@ -27,11 +27,11 @@ import java.util.List;
 import java.util.Optional;
 
 import static kr.modusplant.domains.member.common.constant.ReportConstant.TEST_REPORT_SIZE;
+import static kr.modusplant.domains.member.common.util.domain.vo.ActivitySubjectPostIdTestUtils.testActivitySubjectPostId;
 import static kr.modusplant.domains.member.common.util.domain.vo.ReportIdTestUtils.testReportId;
 import static kr.modusplant.domains.member.common.util.usecase.model.read.PostAbuseReportDashboardReadModelTestUtils.testPostAbuseReportDashboardReadModel;
 import static kr.modusplant.domains.member.common.util.usecase.model.read.PostAbuseReportDashboardReadModelTestUtils.testPostAbuseReportDashboardReadModelList;
 import static kr.modusplant.domains.member.common.util.usecase.model.read.ProposalOrBugReportDashboardReadModelTestUtils.testProposalOrBugReportDashboardCheckedReadModel;
-import static kr.modusplant.domains.member.common.util.domain.vo.ActivitySubjectPostIdTestUtils.testActivitySubjectPostId;
 import static kr.modusplant.domains.member.domain.exception.enums.MemberErrorCode.NOT_FOUND_POST_ABUSE_REPORT;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 import static kr.modusplant.infrastructure.config.jackson.JacksonConfig.objectMapper;

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/ActivitySubjectCommentRepositoryJpaAdapterTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/ActivitySubjectCommentRepositoryJpaAdapterTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mockito;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.util.domain.vo.ActivitySubjectCommentIdTestUtils.testActivitySubjectCommentId;
 import static kr.modusplant.domains.member.common.util.domain.vo.MemberIdTestUtils.testMemberId;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
@@ -30,7 +30,7 @@ class ActivitySubjectCommentRepositoryJpaAdapterTest {
     @DisplayName("isIdExist로 true 반환")
     void testIsIdExist_givenIdThatExists_willReturnTrue() {
         // given & when
-        given(commentJpaRepository.existsByPostUlidAndPath(TEST_POST_ULID, TEST_COMM_COMMENT_PATH)).willReturn(true);
+        given(commentJpaRepository.existsByPostUlidAndPath(TEST_POST_ULID, TEST_COMMENT_PATH)).willReturn(true);
 
         // when & then
         assertThat(activitySubjectCommentRepositoryJpaAdapter.isIdExist(testActivitySubjectCommentId)).isEqualTo(true);
@@ -40,7 +40,7 @@ class ActivitySubjectCommentRepositoryJpaAdapterTest {
     @DisplayName("isIdExist로 false 반환")
     void testIsIdExist_givenIdThatIsNotExist_willReturnFalse() {
         // given & when
-        given(commentJpaRepository.existsByPostUlidAndPath(TEST_POST_ULID, TEST_COMM_COMMENT_PATH)).willReturn(false);
+        given(commentJpaRepository.existsByPostUlidAndPath(TEST_POST_ULID, TEST_COMMENT_PATH)).willReturn(false);
 
         // when & then
         assertThat(activitySubjectCommentRepositoryJpaAdapter.isIdExist(testActivitySubjectCommentId)).isEqualTo(false);
@@ -50,7 +50,7 @@ class ActivitySubjectCommentRepositoryJpaAdapterTest {
     @DisplayName("isLiked로 true 반환")
     void testIsLiked_givenIdThatExists_willReturnTrue() {
         // given & when
-        given(commentLikeJpaRepository.existsByPostIdAndPathAndMemberId(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, testMemberId.getValue())).willReturn(true);
+        given(commentLikeJpaRepository.existsByPostIdAndPathAndMemberId(TEST_POST_ULID, TEST_COMMENT_PATH, testMemberId.getValue())).willReturn(true);
 
         // when & then
         assertThat(activitySubjectCommentRepositoryJpaAdapter.isLiked(testMemberId, testActivitySubjectCommentId)).isEqualTo(true);
@@ -60,7 +60,7 @@ class ActivitySubjectCommentRepositoryJpaAdapterTest {
     @DisplayName("isLiked로 false 반환")
     void testIsLiked_givenIdThatIsNotExist_willReturnFalse() {
         // given & when
-        given(commentLikeJpaRepository.existsByPostIdAndPathAndMemberId(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, testMemberId.getValue())).willReturn(false);
+        given(commentLikeJpaRepository.existsByPostIdAndPathAndMemberId(TEST_POST_ULID, TEST_COMMENT_PATH, testMemberId.getValue())).willReturn(false);
 
         // when & then
         assertThat(activitySubjectCommentRepositoryJpaAdapter.isLiked(testMemberId, testActivitySubjectCommentId)).isEqualTo(false);
@@ -70,7 +70,7 @@ class ActivitySubjectCommentRepositoryJpaAdapterTest {
     @DisplayName("isUnliked로 true 반환")
     void testIsUnliked_givenIdThatExists_willReturnTrue() {
         // given & when
-        given(commentLikeJpaRepository.existsByPostIdAndPathAndMemberId(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, testMemberId.getValue())).willReturn(false);
+        given(commentLikeJpaRepository.existsByPostIdAndPathAndMemberId(TEST_POST_ULID, TEST_COMMENT_PATH, testMemberId.getValue())).willReturn(false);
 
         // when & then
         assertThat(activitySubjectCommentRepositoryJpaAdapter.isUnliked(testMemberId, testActivitySubjectCommentId)).isEqualTo(true);
@@ -80,7 +80,7 @@ class ActivitySubjectCommentRepositoryJpaAdapterTest {
     @DisplayName("isUnliked로 false 반환")
     void testIsUnliked_givenIdThatIsNotExist_willReturnFalse() {
         // given & when
-        given(commentLikeJpaRepository.existsByPostIdAndPathAndMemberId(TEST_POST_ULID, TEST_COMM_COMMENT_PATH, testMemberId.getValue())).willReturn(true);
+        given(commentLikeJpaRepository.existsByPostIdAndPathAndMemberId(TEST_POST_ULID, TEST_COMMENT_PATH, testMemberId.getValue())).willReturn(true);
 
         // when & then
         assertThat(activitySubjectCommentRepositoryJpaAdapter.isUnliked(testMemberId, testActivitySubjectCommentId)).isEqualTo(false);

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/entity/CommentLikeEntityTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/entity/CommentLikeEntityTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMM_COMMENT_PATH;
+import static kr.modusplant.domains.comment.common.constant.CommentConstant.TEST_COMMENT_PATH;
 import static kr.modusplant.domains.member.common.util.domain.vo.MemberIdTestUtils.testMemberId;
 import static kr.modusplant.domains.post.common.constant.PostConstant.TEST_POST_ULID;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +33,7 @@ public class CommentLikeEntityTest implements CommentLikeEntityTestUtils {
     void setUp() {
         // given
         postId = TEST_POST_ULID;
-        path = TEST_COMM_COMMENT_PATH;
+        path = TEST_COMMENT_PATH;
         memberId = createMemberBasicUserEntityWithUuid().getUuid();
 
         CommentLikeEntity commentLikeEntity = CommentLikeEntity.of(postId, path, memberId);

--- a/src/test/java/kr/modusplant/domains/post/domain/aggregate/PostTest.java
+++ b/src/test/java/kr/modusplant/domains/post/domain/aggregate/PostTest.java
@@ -5,7 +5,6 @@ import kr.modusplant.domains.post.domain.exception.EmptyValueException;
 import kr.modusplant.domains.post.domain.exception.InvalidValueException;
 import kr.modusplant.domains.post.domain.vo.LikeCount;
 import kr.modusplant.domains.post.domain.vo.PostContent;
-import kr.modusplant.domains.post.domain.vo.PostId;
 import kr.modusplant.domains.post.domain.vo.PostStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;


### PR DESCRIPTION
- Feat: 관리자 전용 API 관련 다수의 추가 및 변경 등
- Refactor: @SecurityRequirement를 MemberAdminRestController의 클래스 수준에서 선언
- Refactor: 댓글 REST 컨트롤러에서 @Operation 어노테이션에 security 속성 추가