### PR TITLE
:recycle: Refactor: 소셜 인증 팩토리 OCP 구조 개선

### DIFF
--- a/src/main/java/kr/modusplant/domains/account/social/adapter/controller/SocialIdentityController.java
+++ b/src/main/java/kr/modusplant/domains/account/social/adapter/controller/SocialIdentityController.java
@@ -36,7 +36,7 @@ public class SocialIdentityController {
     public SocialLoginResult handleSocialLogin(SocialProvider provider, String code, boolean isLocal) {
         SocialAuthClient authClient = clientFactory.getClient(provider);
         // 소셜 토큰 및 사용자 정보 가져오기 - getToken 메서드를 getTokenInfo 같은걸로 변경
-        SocialUserInfo socialUserInfo = authClient.getToken(code, isLocal);
+        SocialUserInfo socialUserInfo = authClient.getTokenInfo(code, isLocal);
         // 사용자 생성 및 조회
         return classifyMember(socialIdentityMapper.toSocialProfile(provider,socialUserInfo), socialUserInfo.socialAccessToken());
     }

--- a/src/main/java/kr/modusplant/domains/account/social/adapter/controller/SocialIdentityLinkController.java
+++ b/src/main/java/kr/modusplant/domains/account/social/adapter/controller/SocialIdentityLinkController.java
@@ -28,7 +28,7 @@ public class SocialIdentityLinkController {
     private final SocialIdentityMapper socialIdentityMapper;
 
     public SocialUserInfo issueSocialToken(SocialProvider provider, String code, boolean isLocal) {
-        return clientFactory.getClient(provider).getToken(code, isLocal);
+        return clientFactory.getClient(provider).getTokenInfo(code, isLocal);
     }
 
     @Transactional

--- a/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/GoogleAuthClient.java
+++ b/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/GoogleAuthClient.java
@@ -51,7 +51,7 @@ public class GoogleAuthClient implements SocialAuthClient {
     }
 
     @Override
-    public SocialUserInfo getToken(String code, boolean isLocal) {
+    public SocialUserInfo getTokenInfo(String code, boolean isLocal) {
         RestClient restClient = restClientBuilder
                 .baseUrl("https://oauth2.googleapis.com")
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)

--- a/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/GoogleAuthClient.java
+++ b/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/GoogleAuthClient.java
@@ -46,6 +46,11 @@ public class GoogleAuthClient implements SocialAuthClient {
     private String GOOGLE_LOCAL_REDIRECT_URI;
 
     @Override
+    public SocialProvider getProvider() {
+        return SocialProvider.GOOGLE;
+    }
+
+    @Override
     public SocialUserInfo getToken(String code, boolean isLocal) {
         RestClient restClient = restClientBuilder
                 .baseUrl("https://oauth2.googleapis.com")

--- a/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/KakaoAuthClient.java
+++ b/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/KakaoAuthClient.java
@@ -49,7 +49,7 @@ public class KakaoAuthClient implements SocialAuthClient {
     }
 
     @Override
-    public SocialUserInfo getToken(String code, boolean isLocal) {
+    public SocialUserInfo getTokenInfo(String code, boolean isLocal) {
         RestClient restClient = restClientBuilder
                 .baseUrl("https://kauth.kakao.com")
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)

--- a/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/KakaoAuthClient.java
+++ b/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/KakaoAuthClient.java
@@ -43,6 +43,10 @@ public class KakaoAuthClient implements SocialAuthClient {
     @Value("${kakao.local-redirect-uri:#{null}}")
     private String KAKAO_LOCAL_REDIRECT_URI;
 
+    @Override
+    public SocialProvider getProvider() {
+        return SocialProvider.KAKAO;
+    }
 
     @Override
     public SocialUserInfo getToken(String code, boolean isLocal) {

--- a/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/SocialAuthClientFactoryImpl.java
+++ b/src/main/java/kr/modusplant/domains/account/social/framework/outbound/client/SocialAuthClientFactoryImpl.java
@@ -4,21 +4,29 @@ import kr.modusplant.domains.account.social.domain.vo.enums.SocialProvider;
 import kr.modusplant.domains.account.social.framework.outbound.exception.UnsupportedSocialProviderException;
 import kr.modusplant.domains.account.social.usecase.port.client.SocialAuthClient;
 import kr.modusplant.domains.account.social.usecase.port.client.SocialAuthClientFactory;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Component
-@RequiredArgsConstructor
 public class SocialAuthClientFactoryImpl implements SocialAuthClientFactory {
-    private final KakaoAuthClient kakaoAuthClient;
-    private final GoogleAuthClient googleAuthClient;
+    private final Map<SocialProvider, SocialAuthClient> clientMap;
+
+    public SocialAuthClientFactoryImpl(List<SocialAuthClient> clients) {
+        this.clientMap = clients.stream()
+                .collect(Collectors.toMap(
+                        SocialAuthClient::getProvider,
+                        Function.identity()
+                ));
+    }
 
     @Override
     public SocialAuthClient getClient(SocialProvider provider) {
-        return switch (provider) {
-            case KAKAO -> kakaoAuthClient;
-            case GOOGLE -> googleAuthClient;
-            default -> throw new UnsupportedSocialProviderException();
-        };
+        return Optional.ofNullable(clientMap.get(provider))
+                .orElseThrow(UnsupportedSocialProviderException::new);
     }
 }

--- a/src/main/java/kr/modusplant/domains/account/social/usecase/port/client/SocialAuthClient.java
+++ b/src/main/java/kr/modusplant/domains/account/social/usecase/port/client/SocialAuthClient.java
@@ -6,6 +6,6 @@ import kr.modusplant.domains.account.social.usecase.record.SocialUserInfo;
 
 public interface SocialAuthClient {
     SocialProvider getProvider();
-    SocialUserInfo getToken(String code, boolean isLocal);
+    SocialUserInfo getTokenInfo(String code, boolean isLocal);
     void revokeAccess(String accessToken);
 }

--- a/src/main/java/kr/modusplant/domains/account/social/usecase/port/client/SocialAuthClient.java
+++ b/src/main/java/kr/modusplant/domains/account/social/usecase/port/client/SocialAuthClient.java
@@ -1,9 +1,11 @@
 package kr.modusplant.domains.account.social.usecase.port.client;
 
 
+import kr.modusplant.domains.account.social.domain.vo.enums.SocialProvider;
 import kr.modusplant.domains.account.social.usecase.record.SocialUserInfo;
 
 public interface SocialAuthClient {
+    SocialProvider getProvider();
     SocialUserInfo getToken(String code, boolean isLocal);
     void revokeAccess(String accessToken);
 }

--- a/src/test/java/kr/modusplant/domains/account/social/adapter/controller/SocialIdentityControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/account/social/adapter/controller/SocialIdentityControllerTest.java
@@ -54,7 +54,7 @@ class SocialIdentityControllerTest implements SocialAuthRequestTestUtils, Social
         SocialAuthClient authClient = mock(SocialAuthClient.class);
         SocialUserInfo userInfo = mock(SocialUserInfo.class);
         given(clientFactory.getClient(SocialProvider.KAKAO)).willReturn(authClient);
-        given(authClient.getToken(code,false)).willReturn(userInfo);
+        given(authClient.getTokenInfo(code,false)).willReturn(userInfo);
         given(userInfo.socialAccessToken()).willReturn(socialAccessToken);
         given(socialIdentityMapper.toSocialProfile(SocialProvider.KAKAO,userInfo)).willReturn(testKakaoSocialProfile);
         given(socialIdentityRepository.getSocialMemberProfileByEmail(testKakaoSocialProfile.getEmail())).willReturn(Optional.empty());
@@ -66,7 +66,7 @@ class SocialIdentityControllerTest implements SocialAuthRequestTestUtils, Social
         assertEquals(result,createKakaoNeedSignupResult());
         assertThat(result).isInstanceOf(NeedSignupResult.class);
         verify(clientFactory).getClient(SocialProvider.KAKAO);
-        verify(authClient).getToken(code, false);
+        verify(authClient).getTokenInfo(code, false);
         verify(userInfo).socialAccessToken();
         verify(socialIdentityMapper).toSocialProfile(SocialProvider.KAKAO,userInfo);
         verify(socialIdentityRepository).getSocialMemberProfileByEmail(testKakaoSocialProfile.getEmail());
@@ -81,7 +81,7 @@ class SocialIdentityControllerTest implements SocialAuthRequestTestUtils, Social
         SocialAuthClient authClient = mock(SocialAuthClient.class);
         SocialUserInfo userInfo = mock(SocialUserInfo.class);
         given(clientFactory.getClient(SocialProvider.KAKAO)).willReturn(authClient);
-        given(authClient.getToken(code, false)).willReturn(userInfo);
+        given(authClient.getTokenInfo(code, false)).willReturn(userInfo);
         given(userInfo.socialAccessToken()).willReturn(socialAccessToken);
         given(socialIdentityMapper.toSocialProfile(SocialProvider.KAKAO,userInfo)).willReturn(testKakaoSocialProfileWithBasicEmail);
         given(socialIdentityRepository.getSocialMemberProfileByEmail(testKakaoSocialProfileWithBasicEmail.getEmail()))
@@ -94,7 +94,7 @@ class SocialIdentityControllerTest implements SocialAuthRequestTestUtils, Social
         assertEquals(result,createKakaoNeedLinkResult());
         assertThat(result).isInstanceOf(NeedLinkResult.class);
         verify(clientFactory).getClient(SocialProvider.KAKAO);
-        verify(authClient).getToken(code, false);
+        verify(authClient).getTokenInfo(code, false);
         verify(userInfo).socialAccessToken();
         verify(socialIdentityMapper).toSocialProfile(SocialProvider.KAKAO,userInfo);
         verify(socialIdentityRepository).getSocialMemberProfileByEmail(testKakaoSocialProfileWithBasicEmail.getEmail());
@@ -110,7 +110,7 @@ class SocialIdentityControllerTest implements SocialAuthRequestTestUtils, Social
         SocialUserInfo userInfo = mock(SocialUserInfo.class);
 
         given(clientFactory.getClient(SocialProvider.KAKAO)).willReturn(authClient);
-        given(authClient.getToken(code, false)).willReturn(userInfo);
+        given(authClient.getTokenInfo(code, false)).willReturn(userInfo);
         given(userInfo.socialAccessToken()).willReturn(socialAccessToken);
         given(socialIdentityMapper.toSocialProfile(SocialProvider.KAKAO,userInfo)).willReturn(testKakaoSocialProfileWithBasicEmail);
         given(socialIdentityRepository.getSocialMemberProfileByEmail(testKakaoSocialProfileWithBasicEmail.getEmail())).willReturn(Optional.of(testGoogleSocialMemberProfileWithBasicEmail));
@@ -132,7 +132,7 @@ class SocialIdentityControllerTest implements SocialAuthRequestTestUtils, Social
         SocialUserInfo userInfo = mock(SocialUserInfo.class);
 
         given(clientFactory.getClient(SocialProvider.GOOGLE)).willReturn(authClient);
-        given(authClient.getToken(code,false)).willReturn(userInfo);
+        given(authClient.getTokenInfo(code,false)).willReturn(userInfo);
         given(userInfo.socialAccessToken()).willReturn(TEST_SOCIAL_GOOGLE_SOCIAL_ACCESS_TOKEN);
         given(socialIdentityMapper.toSocialProfile(SocialProvider.GOOGLE, userInfo)).willReturn(testGoogleSocialProfile);
         given(socialIdentityRepository.getSocialMemberProfileByEmail(testGoogleSocialProfile.getEmail())).willReturn(Optional.of(testGoogleSocialMemberProfile));
@@ -165,7 +165,7 @@ class SocialIdentityControllerTest implements SocialAuthRequestTestUtils, Social
                 Role.USER
         );
         given(clientFactory.getClient(SocialProvider.KAKAO)).willReturn(authClient);
-        given(authClient.getToken(code,false)).willReturn(userInfo);
+        given(authClient.getTokenInfo(code,false)).willReturn(userInfo);
         given(userInfo.socialAccessToken()).willReturn(TEST_SOCIAL_KAKAO_SOCIAL_ACCESS_TOKEN);
         given(socialIdentityMapper.toSocialProfile(SocialProvider.KAKAO, userInfo)).willReturn(testKakaoSocialProfile);
         given(socialIdentityRepository.getSocialMemberProfileByEmail(any())).willReturn(Optional.of(differentProviderIdProfile));

--- a/src/test/java/kr/modusplant/domains/account/social/adapter/controller/SocialIdentityLinkControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/account/social/adapter/controller/SocialIdentityLinkControllerTest.java
@@ -49,7 +49,7 @@ class SocialIdentityLinkControllerTest implements SocialMemberProfileTestUtils, 
     void testIssueSocialToken_givenSocialProviderAndCode_willReturnSocialToken() {
         // given
         String code = createTestKakaoLoginRequest().code();
-        given(socialAuthClient.getToken(code, false)).willReturn(kakaoUserInfo);
+        given(socialAuthClient.getTokenInfo(code, false)).willReturn(kakaoUserInfo);
 
         // when
         SocialUserInfo result = socialIdentityLinkController.issueSocialToken(SocialProvider.KAKAO,code, false);
@@ -57,7 +57,7 @@ class SocialIdentityLinkControllerTest implements SocialMemberProfileTestUtils, 
         // then
         assertEquals(result,kakaoUserInfo);
         verify(clientFactory).getClient(SocialProvider.KAKAO);
-        verify(socialAuthClient).getToken(code, false);
+        verify(socialAuthClient).getTokenInfo(code, false);
     }
 
     @Nested

--- a/src/test/java/kr/modusplant/domains/account/social/framework/outbound/client/GoogleAuthClientTest.java
+++ b/src/test/java/kr/modusplant/domains/account/social/framework/outbound/client/GoogleAuthClientTest.java
@@ -86,7 +86,7 @@ class GoogleAuthClientTest {
         given(idTokenParser.parse(expectedIdToken, SocialProvider.GOOGLE)).willReturn(mockIdTokenInfo);
 
         // When
-        SocialUserInfo userInfo = googleAuthClient.getToken(code, false);
+        SocialUserInfo userInfo = googleAuthClient.getTokenInfo(code, false);
 
         // Then
         assertThat(userInfo.socialAccessToken()).isEqualTo(expectedAccessToken);
@@ -98,7 +98,7 @@ class GoogleAuthClientTest {
 
     @Test
     @DisplayName("구글 access token 발급 실패 시 예외 발생 테스트")
-    void testGetToken_givenInvalidCode_willThrowException() {
+    void testGetTokenInfo_givenInvalidCode_willThrowException() {
         // Given
         String authCode = "fake-auth-code";
         String errorBody = "{\"error\":\"invalid_grant\", \"error_description\":\"Bad Request\"}";
@@ -109,7 +109,7 @@ class GoogleAuthClientTest {
                         .body(errorBody));
 
         // When & Then
-        assertThrows(OAuthRequestFailException.class, () -> googleAuthClient.getToken(authCode, false));
+        assertThrows(OAuthRequestFailException.class, () -> googleAuthClient.getTokenInfo(authCode, false));
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/account/social/framework/outbound/client/KakaoAuthClientTest.java
+++ b/src/test/java/kr/modusplant/domains/account/social/framework/outbound/client/KakaoAuthClientTest.java
@@ -55,7 +55,7 @@ class KakaoAuthClientTest {
 
     @Test
     @DisplayName("카카오 access token 발급 성공 테스트")
-    void testGetToken_givenCode_willReturnToken() {
+    void testGetTokenInfo_givenCode_willReturnTokenInfo() {
         // given
         String code = "test-auth-code";
         String expectedAccessToken = "test-access-token";
@@ -83,7 +83,7 @@ class KakaoAuthClientTest {
         given(idTokenParser.parse(expectedIdToken, SocialProvider.KAKAO)).willReturn(mockIdTokenInfo);
 
         // when
-        SocialUserInfo userInfo = kakaoAuthClient.getToken(code, false);
+        SocialUserInfo userInfo = kakaoAuthClient.getTokenInfo(code, false);
 
         // then
         assertThat(userInfo.socialAccessToken()).isEqualTo(expectedAccessToken);
@@ -94,7 +94,7 @@ class KakaoAuthClientTest {
 
     @Test
     @DisplayName("카카오 access token 발급 실패 시 예외 발생 테스트")
-    void testGetToken_givenInvalidCode_willThrowException() {
+    void testGetTokenInfo_givenInvalidCode_willThrowException() {
         // given
         String authCode = "fake-auth-code";
         String errorResponseBody = "{\"error\":\"invalid_grant\", \"error_description\":\"authorization code not found\"}";
@@ -105,7 +105,7 @@ class KakaoAuthClientTest {
                         .body(errorResponseBody));
 
         // when & then
-        assertThrows(OAuthRequestFailException.class, () -> kakaoAuthClient.getToken(authCode, false));
+        assertThrows(OAuthRequestFailException.class, () -> kakaoAuthClient.getTokenInfo(authCode, false));
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/account/social/framework/outbound/client/SocialAuthClientFactoryImplTest.java
+++ b/src/test/java/kr/modusplant/domains/account/social/framework/outbound/client/SocialAuthClientFactoryImplTest.java
@@ -2,15 +2,18 @@ package kr.modusplant.domains.account.social.framework.outbound.client;
 
 import kr.modusplant.domains.account.social.domain.vo.enums.SocialProvider;
 import kr.modusplant.domains.account.social.usecase.port.client.SocialAuthClient;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class SocialAuthClientFactoryImplTest {
@@ -21,8 +24,17 @@ class SocialAuthClientFactoryImplTest {
     @Mock
     private GoogleAuthClient googleAuthClient;
 
-    @InjectMocks
     private SocialAuthClientFactoryImpl socialAuthClientFactory;
+
+    @BeforeEach
+    void setUp() {
+        // 생성자 시점에 stream 조립 로직이 돌기 때문에 Mock 객체들이 어떤 Provider인지 미리 알려주어야 함
+        given(kakaoAuthClient.getProvider()).willReturn(SocialProvider.KAKAO);
+        given(googleAuthClient.getProvider()).willReturn(SocialProvider.GOOGLE);
+
+        // List에 담아서 수동으로 팩토리를 주입,생성 (@InjectMocks 제거)
+        socialAuthClientFactory = new SocialAuthClientFactoryImpl(List.of(kakaoAuthClient, googleAuthClient));
+    }
 
     @Test
     @DisplayName("KAKAO provider로 KakaoAuthClient를 반환한다")


### PR DESCRIPTION
- 소셜인증 팩토리 클래스 내 switch-case 제거 및 자동 주입 구조 전환으로 OCP 달성
- 관련 테스트 코드 수정