### PR TITLE
:sparkles: Feat: 편집/관리용 게시글 데이터 조회 응답에 fileKey 추가

### DIFF
--- a/src/main/java/kr/modusplant/domains/post/adapter/controller/PostController.java
+++ b/src/main/java/kr/modusplant/domains/post/adapter/controller/PostController.java
@@ -80,7 +80,7 @@ public class PostController {
                 .filter(postDetailData -> postDetailData.isPublished() || postDetailData.authorUuid().equals(currentMemberUuid))
                 .map(postDetailData -> postMapper.toPostDetailDataResponse(
                         postDetailData,
-                        getJsonNodeContent(postDetailData.content()),
+                        getJsonNodeContentWithFileKey(postDetailData.content()),
                         contentDataProcessorPort.extractOriginalFilenameFromFileKey(postDetailData.thumbnailPath())))
                 .orElseThrow(PostNotFoundException::new);
     }
@@ -242,6 +242,17 @@ public class PostController {
         JsonNode newContent;
         try {
             newContent = contentDataProcessorPort.convertFileSrcToFullFileSrc(content);
+        } catch (IOException e) {
+            throw new ContentProcessingException();
+        }
+        return newContent;
+    }
+
+    private JsonNode getJsonNodeContentWithFileKey(JsonNode content) {
+        if (content == null) return null;
+        JsonNode newContent;
+        try {
+            newContent = contentDataProcessorPort.convertFileSrcToFullFileSrcWithFileKey(content);
         } catch (IOException e) {
             throw new ContentProcessingException();
         }

--- a/src/main/java/kr/modusplant/domains/post/framework/outbound/processor/PostContentDataProcessor.java
+++ b/src/main/java/kr/modusplant/domains/post/framework/outbound/processor/PostContentDataProcessor.java
@@ -36,6 +36,7 @@ public class PostContentDataProcessor implements ContentDataProcessorPort {
     private final RandomUlidGenerator generator;
     public static final String DATA = "data";
     public static final String FILENAME = "filename";
+    public static final String FILE_KEY = "fileKey";
     public static final String ORDER = "order";
     public static final String SRC = "src";
     public static final String TYPE = "type";
@@ -110,6 +111,14 @@ public class PostContentDataProcessor implements ContentDataProcessorPort {
     }
 
     public ArrayNode convertFileSrcToFullFileSrc(JsonNode content) {
+        return convertFileSrcToFullFileSrc(content, false);
+    }
+
+    public ArrayNode convertFileSrcToFullFileSrcWithFileKey(JsonNode content) {
+        return convertFileSrcToFullFileSrc(content, true);
+    }
+
+    private ArrayNode convertFileSrcToFullFileSrc(JsonNode content, boolean includeFileKey) {
         ArrayNode newArray = objectMapper.createArrayNode();
         for (JsonNode node : content) {
             ObjectNode objectNode = node.deepCopy();
@@ -117,6 +126,9 @@ public class PostContentDataProcessor implements ContentDataProcessorPort {
                 String fileKey = objectNode.get(SRC).asText();
                 objectNode.remove(SRC);
                 String src = amazonS3Service.generateS3SrcUrl(fileKey);
+                if (includeFileKey) {
+                    objectNode.put(FILE_KEY, fileKey);
+                }
                 objectNode.put(SRC,src);
             }
             newArray.add(objectNode);

--- a/src/main/java/kr/modusplant/domains/post/usecase/port/processor/ContentDataProcessorPort.java
+++ b/src/main/java/kr/modusplant/domains/post/usecase/port/processor/ContentDataProcessorPort.java
@@ -17,6 +17,8 @@ public interface ContentDataProcessorPort {
 
     ArrayNode convertFileSrcToFullFileSrc(JsonNode content) throws IOException;
 
+    ArrayNode convertFileSrcToFullFileSrcWithFileKey(JsonNode content) throws IOException;
+
     ArrayNode convertToPreview(JsonNode content, String thumbnailPath) throws IOException;
 
     void deleteFiles(JsonNode content);

--- a/src/test/java/kr/modusplant/domains/post/adapter/controller/PostControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/post/adapter/controller/PostControllerTest.java
@@ -157,7 +157,7 @@ class PostControllerTest implements PostTestUtils, PostReadModelTestUtils, PostR
     void testGetDataByUlid_givenPublishedPostAndAuthor_willReturnPostDetail() throws IOException {
         // given
         given(postQueryRepository.findPostDetailDataByPostId(any(PostId.class))).willReturn(Optional.of(TEST_PUBLISHED_POST_DETAIL_DATA_READ_MODEL));
-        given(contentDataProcessorPort.convertFileSrcToFullFileSrc(any(JsonNode.class))).willReturn((ArrayNode) TEST_POST_CONTENT_TEXT_AND_IMAGE);
+        given(contentDataProcessorPort.convertFileSrcToFullFileSrcWithFileKey(any(JsonNode.class))).willReturn((ArrayNode) TEST_POST_CONTENT_TEXT_AND_IMAGE);
         given(contentDataProcessorPort.extractOriginalFilenameFromFileKey(anyString())).willReturn(TEST_POST_CONTENT_THUMBNAIL_FILENAME);
 
         // when
@@ -166,7 +166,7 @@ class PostControllerTest implements PostTestUtils, PostReadModelTestUtils, PostR
         // then
         assertThat(result).isNotNull();
         verify(postQueryRepository).findPostDetailDataByPostId(any(PostId.class));
-        verify(contentDataProcessorPort).convertFileSrcToFullFileSrc(any(JsonNode.class));
+        verify(contentDataProcessorPort).convertFileSrcToFullFileSrcWithFileKey(any(JsonNode.class));
         verify(contentDataProcessorPort).extractOriginalFilenameFromFileKey(anyString());
     }
 
@@ -175,7 +175,7 @@ class PostControllerTest implements PostTestUtils, PostReadModelTestUtils, PostR
     void testGetDataByUlid_givenDraftPostAndAuthor_willReturnPostDetail() throws IOException {
         // given
         given(postQueryRepository.findPostDetailDataByPostId(any(PostId.class))).willReturn(Optional.of(TEST_DRAFT_POST_DETAIL_DATA_READ_MODEL));
-        given(contentDataProcessorPort.convertFileSrcToFullFileSrc(any(JsonNode.class))).willReturn((ArrayNode) TEST_POST_CONTENT_TEXT_AND_IMAGE);
+        given(contentDataProcessorPort.convertFileSrcToFullFileSrcWithFileKey(any(JsonNode.class))).willReturn((ArrayNode) TEST_POST_CONTENT_TEXT_AND_IMAGE);
         given(contentDataProcessorPort.extractOriginalFilenameFromFileKey(anyString())).willReturn(TEST_POST_CONTENT_THUMBNAIL_FILENAME);
 
         // when
@@ -184,7 +184,7 @@ class PostControllerTest implements PostTestUtils, PostReadModelTestUtils, PostR
         // then
         assertThat(result).isNotNull();
         verify(postQueryRepository).findPostDetailDataByPostId(any(PostId.class));
-        verify(contentDataProcessorPort).convertFileSrcToFullFileSrc(any(JsonNode.class));
+        verify(contentDataProcessorPort).convertFileSrcToFullFileSrcWithFileKey(any(JsonNode.class));
         verify(contentDataProcessorPort).extractOriginalFilenameFromFileKey(anyString());
     }
 
@@ -200,7 +200,7 @@ class PostControllerTest implements PostTestUtils, PostReadModelTestUtils, PostR
         assertThatThrownBy(() -> postController.getDataByUlid(TEST_POST_ULID, otherMemberUuid))
                 .isInstanceOf(PostNotFoundException.class);
         verify(postQueryRepository).findPostDetailDataByPostId(any(PostId.class));
-        verify(contentDataProcessorPort, never()).convertFileSrcToFullFileSrc(any(JsonNode.class));
+        verify(contentDataProcessorPort, never()).convertFileSrcToFullFileSrcWithFileKey(any(JsonNode.class));
         verify(contentDataProcessorPort, never()).extractOriginalFilenameFromFileKey(anyString());
     }
 
@@ -217,7 +217,7 @@ class PostControllerTest implements PostTestUtils, PostReadModelTestUtils, PostR
         // then
         assertThat(result).isNotNull();
         verify(postQueryRepository).findPostDetailDataByPostId(any(PostId.class));
-        verify(contentDataProcessorPort,never()).convertFileSrcToFullFileSrc(any(JsonNode.class));
+        verify(contentDataProcessorPort,never()).convertFileSrcToFullFileSrcWithFileKey(any(JsonNode.class));
         verify(contentDataProcessorPort).extractOriginalFilenameFromFileKey(null);
     }
 

--- a/src/test/java/kr/modusplant/domains/post/framework/outbound/processor/PostContentDataProcessorTest.java
+++ b/src/test/java/kr/modusplant/domains/post/framework/outbound/processor/PostContentDataProcessorTest.java
@@ -48,6 +48,7 @@ class PostContentDataProcessorTest implements PostRequestTestUtils, PostFileUplo
 
     private static final String DATA = "data";
     private static final String FILENAME = "filename";
+    private static final String FILE_KEY = "fileKey";
     private static final String ORDER = "order";
     private static final String SRC = "src";
     private static final String TYPE = "type";
@@ -345,8 +346,37 @@ class PostContentDataProcessorTest implements PostRequestTestUtils, PostFileUplo
             JsonNode imageNode = result.get(0);
             assertThat(imageNode.has(SRC)).isTrue();
             assertThat(imageNode.has(DATA)).isFalse();
+            assertThat(imageNode.has(FILE_KEY)).isFalse();
             assertThat(imageNode.get(TYPE).asText()).isEqualTo(PostFileType.IMAGE.getValue());
             assertThat(imageNode.get(SRC).asText()).isEqualTo(fullSrcUrl);
+        }
+    }
+
+    @Nested
+    @DisplayName("convertFileSrcToFullFileSrcWithFileKey 메서드 테스트")
+    class testConvertFileSrcToFullFileSrcWithFileKey {
+        @Test
+        @DisplayName("저장된 파일 경로를 전체 파일 경로로 변환하면서 fileKey도 함께 반환")
+        void testConvertFileSrcToFullFileSrcWithFileKey_givenJsonContent_willReturnArrayNodeContentWithFileKey() throws IOException {
+            // given
+            JsonNode content = postContentDataProcessor.generateContentJson(null, onlyImageFilesOrder, TEST_IMAGE_JPG_FILENAME).content();
+            String fullSrcUrl = BASIC_PATH + TEST_IMAGE_JPG_FILE_KEY;
+            given(amazonS3Service.generateS3SrcUrl(anyString())).willReturn(fullSrcUrl);
+
+            // when
+            JsonNode result = postContentDataProcessor.convertFileSrcToFullFileSrcWithFileKey(content);
+
+            // then
+            assertThat(result.isArray()).isTrue();
+            assertThat(result.size()).isEqualTo(1);
+
+            JsonNode imageNode = result.get(0);
+            assertThat(imageNode.has(SRC)).isTrue();
+            assertThat(imageNode.has(DATA)).isFalse();
+            assertThat(imageNode.has(FILE_KEY)).isTrue();
+            assertThat(imageNode.get(TYPE).asText()).isEqualTo(PostFileType.IMAGE.getValue());
+            assertThat(imageNode.get(SRC).asText()).isEqualTo(fullSrcUrl);
+            assertThat(imageNode.get(FILE_KEY).asText()).isEqualTo(TEST_IMAGE_JPG_FILE_KEY);
         }
     }
 


### PR DESCRIPTION
- 게시글 수정 시 프론트엔드에서 Presigned URL 방식으로 파일을 재업로드/교체하려면 원본 fileKey가 필요
- 편집/관리용 게시글 데이터 조회 API의 content 응답에 파일별 fileKey 필드를 추가로 반환