### PR TITLE
🐛 Fix: 회원 프로필 API에서 여러 이유로 500 Error가 발생하던 문제 해소

### DIFF
--- a/.claude/rules/member-domain-details.md
+++ b/.claude/rules/member-domain-details.md
@@ -122,6 +122,7 @@ member/
 - Used only for controller
 - `*ValidationHelper`: DB-backed pre-condition checks via repository ports
 - `*IOHelper`: external I/O operations (S3 upload/delete, etc.); a presigned-URL issuance method also registers the returned file key as pending via the global `PendingFileService`, so an S3 upload never confirmed by a DB write can later be cleaned up as an orphan
+- `*IOHelper` may also expose an S3-backed validation (e.g. `validateIfImageExists`), complementing the DB-backed checks in `*ValidationHelper`
 
 **Listener** (`adapter/listener/`) — `@Component`:
 - `@EventListener` / `@TransactionalEventListener`; apply Semaphore bulkhead when concurrency control is needed

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,8 @@
       "Bash(docker compose down*)",
 
       "Read(**/.gradle/**)",
-      "Read(**/.settings/**)"
+      "Read(**/.settings/**)",
+      "Read(./src/main/resources/application-secrets.yml)"
     ]
   },
   "env": {

--- a/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberController.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberController.java
@@ -27,6 +27,7 @@ import kr.modusplant.shared.exception.EmptyValueException;
 import kr.modusplant.shared.exception.InvalidValueException;
 import kr.modusplant.shared.exception.NotAccessibleException;
 import kr.modusplant.shared.framework.jpa.exception.ExistsEntityException;
+import kr.modusplant.shared.framework.jpa.exception.NotFoundEntityException;
 import kr.modusplant.shared.kernel.Nickname;
 import kr.modusplant.shared.kernel.enums.KernelErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -95,7 +96,7 @@ public class MemberController {
     public MemberProfileResponseWithImageUrl overrideProfile(MemberProfileOverrideRecord_V1 record) throws IOException {
         MemberId memberId = MemberId.fromUuid(record.id());
         Nickname memberNickname = Nickname.create(record.nickname());
-        validateBeforeOverrideProfile(memberId, memberNickname);
+        validateBeforeOverrideProfile(memberId, memberNickname, null);
 
         MemberProfile memberProfile = memberProfileRepository.getByIdWithoutImageBytes(memberId);
         memberImageIOHelper.deleteImage(memberProfile.getMemberProfileImage());
@@ -140,12 +141,12 @@ public class MemberController {
     public MemberProfileResponseWithImageUrl overrideProfile(MemberProfileOverrideRecord_V2 record) throws IOException {
         MemberId memberId = MemberId.fromUuid(record.id());
         Nickname memberNickname = Nickname.create(record.nickname());
-        validateBeforeOverrideProfile(memberId, memberNickname);
-
         MemberProfileImage memberProfileImage = MemberProfileImage.create(
                 MemberProfileImagePath.create(record.fileKey()),
                 MemberProfileImageBytes.create(null)
         );
+        validateBeforeOverrideProfile(memberId, memberNickname, memberProfileImage);
+
         MemberProfileIntroduction memberProfileIntroduction =
                 MemberProfileIntroduction.create(swearService.filterSwear(record.introduction()));
         MemberProfile memberProfile = MemberProfile.create(
@@ -158,12 +159,12 @@ public class MemberController {
     public MemberProfileResponseWithImagePath overrideProfile(MemberProfileOverrideRecord_V3 record) throws IOException {
         MemberId memberId = MemberId.fromUuid(record.id());
         Nickname memberNickname = Nickname.create(record.nickname());
-        validateBeforeOverrideProfile(memberId, memberNickname);
-
         MemberProfileImage memberProfileImage = MemberProfileImage.create(
                 MemberProfileImagePath.create(record.fileKey()),
                 MemberProfileImageBytes.create(null)
         );
+        validateBeforeOverrideProfile(memberId, memberNickname, memberProfileImage);
+
         MemberProfileIntroduction memberProfileIntroduction =
                 MemberProfileIntroduction.create(swearService.filterSwear(record.introduction()));
         MemberProfile memberProfile = MemberProfile.create(
@@ -377,7 +378,7 @@ public class MemberController {
         memberRepository.withdraw(memberId, record.reason(), MemberWithdrawOpinion.create(record.opinion()));
     }
 
-    private void validateBeforeOverrideProfile(MemberId memberId, Nickname nickname) {
+    private void validateBeforeOverrideProfile(MemberId memberId, Nickname nickname, MemberProfileImage memberProfileImage) {
         memberValidationHelper.validateIfMemberExists(memberId);
         if (swearService.isSwearContained(nickname.getValue())) {
             throw new SwearContainedException();
@@ -385,6 +386,10 @@ public class MemberController {
         Optional<Member> emptyOrMember = memberRepository.getByNickname(nickname);
         if (emptyOrMember.isPresent() && !emptyOrMember.orElseThrow().getMemberId().equals(memberId)) {
             throw new ExistsEntityException(KernelErrorCode.EXISTS_NICKNAME, "nickname");
+        }
+        if (memberProfileImage != null &&
+                !memberProfileRepository.isImagePathExist(memberProfileImage.getMemberProfileImagePath())) {
+            throw new NotFoundEntityException(NOT_FOUND_MEMBER_PROFILE, "memberProfileImagePath");
         }
     }
 

--- a/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberController.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberController.java
@@ -27,7 +27,6 @@ import kr.modusplant.shared.exception.EmptyValueException;
 import kr.modusplant.shared.exception.InvalidValueException;
 import kr.modusplant.shared.exception.NotAccessibleException;
 import kr.modusplant.shared.framework.jpa.exception.ExistsEntityException;
-import kr.modusplant.shared.framework.jpa.exception.NotFoundEntityException;
 import kr.modusplant.shared.kernel.Nickname;
 import kr.modusplant.shared.kernel.enums.KernelErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -387,9 +386,8 @@ public class MemberController {
         if (emptyOrMember.isPresent() && !emptyOrMember.orElseThrow().getMemberId().equals(memberId)) {
             throw new ExistsEntityException(KernelErrorCode.EXISTS_NICKNAME, "nickname");
         }
-        if (memberProfileImage != null &&
-                !memberProfileRepository.isImagePathExist(memberProfileImage.getMemberProfileImagePath())) {
-            throw new NotFoundEntityException(NOT_FOUND_MEMBER_PROFILE, "memberProfileImagePath");
+        if (memberProfileImage != null) {
+            memberImageIOHelper.validateIfImageExists(memberProfileImage.getMemberProfileImagePath());
         }
     }
 

--- a/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberController.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/controller/MemberController.java
@@ -17,11 +17,7 @@ import kr.modusplant.domains.member.usecase.port.mapper.MemberProfileMapper;
 import kr.modusplant.domains.member.usecase.port.mapper.ProposalOrBugReportMapper;
 import kr.modusplant.domains.member.usecase.port.repository.*;
 import kr.modusplant.domains.member.usecase.record.*;
-import kr.modusplant.domains.member.usecase.response.MemberProfilePrepareResponse;
-import kr.modusplant.domains.member.usecase.response.MemberProfileResponseWithImagePath;
-import kr.modusplant.domains.member.usecase.response.MemberProfileResponseWithImageUrl;
-import kr.modusplant.domains.member.usecase.response.MemberRoleResponse;
-import kr.modusplant.domains.member.usecase.response.ProposalOrBugReportPrepareResponse;
+import kr.modusplant.domains.member.usecase.response.*;
 import kr.modusplant.infrastructure.jwt.provider.JwtTokenProvider;
 import kr.modusplant.infrastructure.jwt.service.TokenService;
 import kr.modusplant.infrastructure.swear.exception.SwearContainedException;
@@ -121,7 +117,7 @@ public class MemberController {
         memberProfile = MemberProfile.create(memberId, memberProfileImage, memberProfileIntroduction, memberNickname);
         return (MemberProfileResponseWithImageUrl)
                 memberProfileMapper.toMemberProfileResponse(
-                        memberProfileRepository.update(memberProfile, false), 1);
+                        memberProfileRepository.update(memberProfile, false, true), 1);
     }
 
     public MemberProfilePrepareResponse prepareMemberProfileImage(MemberProfileImagePrepareRecord_V2 record) throws IOException {
@@ -132,7 +128,7 @@ public class MemberController {
         MemberProfile existingMemberProfile = memberProfileRepository.getByIdWithoutImageBytes(memberId);
         memberImageIOHelper.deleteImage(existingMemberProfile.getMemberProfileImage());
         existingMemberProfile.clearImage();
-        memberProfileRepository.update(existingMemberProfile, false);
+        memberProfileRepository.update(existingMemberProfile, false, false);
 
         MemberProfileImagePath memberProfileImagePath =
                 MemberProfileImagePath.create(memberId, memberProfileImageFileName);
@@ -156,7 +152,7 @@ public class MemberController {
                 memberId, memberProfileImage, memberProfileIntroduction, memberNickname);
         return (MemberProfileResponseWithImageUrl)
                 memberProfileMapper.toMemberProfileResponse(
-                        memberProfileRepository.update(memberProfile, true), 2);
+                        memberProfileRepository.update(memberProfile, true, false), 2);
     }
 
     public MemberProfileResponseWithImagePath overrideProfile(MemberProfileOverrideRecord_V3 record) throws IOException {
@@ -174,7 +170,7 @@ public class MemberController {
                 memberId, memberProfileImage, memberProfileIntroduction, memberNickname);
         return (MemberProfileResponseWithImagePath)
                 memberProfileMapper.toMemberProfileResponse(
-                        memberProfileRepository.update(memberProfile, true), 3);
+                        memberProfileRepository.update(memberProfile, true, false), 3);
     }
 
     public void likePost(MemberPostLikeRecord record) {

--- a/src/main/java/kr/modusplant/domains/member/adapter/helper/MemberImageIOHelper.java
+++ b/src/main/java/kr/modusplant/domains/member/adapter/helper/MemberImageIOHelper.java
@@ -7,6 +7,7 @@ import kr.modusplant.domains.member.domain.vo.ReportId;
 import kr.modusplant.domains.member.domain.vo.ReportImagePath;
 import kr.modusplant.domains.member.usecase.record.MemberProfileOverrideRecord_V1;
 import kr.modusplant.infrastructure.file.service.PendingFileService;
+import kr.modusplant.shared.framework.aws.exception.NotFoundFileKeyOnS3Exception;
 import kr.modusplant.shared.framework.aws.service.AmazonS3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -64,6 +65,13 @@ public class MemberImageIOHelper {
         String imagePath = image.getMemberProfileImagePath().getValue();
         if (imagePath != null) {
             amazonS3Service.deleteFile(imagePath);
+        }
+    }
+
+    public void validateIfImageExists(MemberProfileImagePath memberProfileImagePath) {
+        String imagePath = memberProfileImagePath.getValue();
+        if (imagePath != null && !amazonS3Service.checkIfFileExists(imagePath)) {
+            throw new NotFoundFileKeyOnS3Exception();
         }
     }
 }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapter.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapter.java
@@ -68,9 +68,4 @@ public class MemberProfileRepositoryJpaAdapter implements MemberProfileRepositor
     public boolean isIdExist(MemberId memberId) {
         return memberProfileJpaRepository.existsByUuid(memberId.getValue());
     }
-
-    @Override
-    public boolean isImagePathExist(MemberProfileImagePath memberProfileImagePath) {
-        return memberProfileJpaRepository.existsByImagePath(memberProfileImagePath.getValue());
-    }
 }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapter.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapter.java
@@ -8,7 +8,6 @@ import kr.modusplant.domains.member.domain.vo.MemberProfileImagePath;
 import kr.modusplant.domains.member.domain.vo.MemberProfileIntroduction;
 import kr.modusplant.domains.member.framework.outbound.jpa.entity.MemberProfileEntity;
 import kr.modusplant.domains.member.framework.outbound.jpa.mapper.MemberProfileJpaMapperImpl;
-import kr.modusplant.domains.member.framework.outbound.jpa.repository.MemberJpaRepository;
 import kr.modusplant.domains.member.framework.outbound.jpa.repository.MemberProfileJpaRepository;
 import kr.modusplant.domains.member.usecase.port.repository.MemberProfileRepository;
 import kr.modusplant.infrastructure.file.service.PendingFileService;
@@ -29,7 +28,6 @@ public class MemberProfileRepositoryJpaAdapter implements MemberProfileRepositor
     private final PendingFileService pendingFileService;
 
     private final MemberProfileJpaMapperImpl memberProfileJpaMapper;
-    private final MemberJpaRepository memberJpaRepository;
     private final MemberProfileJpaRepository memberProfileJpaRepository;
 
     @Override
@@ -50,20 +48,7 @@ public class MemberProfileRepositoryJpaAdapter implements MemberProfileRepositor
     }
 
     @Override
-    public MemberProfile add(MemberProfile memberProfile) throws IOException {
-        return memberProfileJpaMapper.toMemberProfile(
-                memberProfileJpaRepository.save(
-                        MemberProfileEntity.builder()
-                                .member(memberJpaRepository
-                                        .findByUuid(memberProfile.getMemberId().getValue())
-                                        .orElseThrow())
-                                .imagePath(memberProfile.getMemberProfileImage().getMemberProfileImagePath().getValue())
-                                .introduction(memberProfile.getMemberProfileIntroduction().getValue())
-                                .build()));
-    }
-
-    @Override
-    public MemberProfile update(MemberProfile memberProfile, boolean needsUntracking) throws IOException {
+    public MemberProfile update(MemberProfile memberProfile, boolean needsUntracking, boolean needsImageBytes) throws IOException {
         String imagePath = memberProfile.getMemberProfileImage().getMemberProfileImagePath().getValue();
         String introduction = memberProfile.getMemberProfileIntroduction().getValue();
         String nickname = memberProfile.getNickname().getValue();
@@ -76,7 +61,7 @@ public class MemberProfileRepositoryJpaAdapter implements MemberProfileRepositor
         if (needsUntracking) {
             pendingFileService.untrackPendingFiles(List.of(imagePath));
         }
-        return memberProfileJpaMapper.toMemberProfile(savedMemberProfileEntity);
+        return memberProfileJpaMapper.toMemberProfile(savedMemberProfileEntity, needsImageBytes);
     }
 
     @Override

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapter.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapter.java
@@ -68,4 +68,9 @@ public class MemberProfileRepositoryJpaAdapter implements MemberProfileRepositor
     public boolean isIdExist(MemberId memberId) {
         return memberProfileJpaRepository.existsByUuid(memberId.getValue());
     }
+
+    @Override
+    public boolean isImagePathExist(MemberProfileImagePath memberProfileImagePath) {
+        return memberProfileJpaRepository.existsByImagePath(memberProfileImagePath.getValue());
+    }
 }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/mapper/MemberProfileJpaMapperImpl.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/mapper/MemberProfileJpaMapperImpl.java
@@ -31,11 +31,11 @@ public class MemberProfileJpaMapperImpl implements MemberProfileJpaMapper {
     }
 
     @Override
-    public MemberProfile toMemberProfile(MemberProfileEntity entity) {
+    public MemberProfile toMemberProfile(MemberProfileEntity entity, boolean needsImageBytes) {
         MemberProfileImagePath memberProfileImagePath =
                 MemberProfileImagePath.create(entity.getImagePath());
         MemberProfileImageBytes memberProfileImageBytes =
-                memberProfileImagePath.getValue() != null ?
+                memberProfileImagePath.getValue() != null && needsImageBytes ?
                         MemberProfileImageBytes.create(
                                 amazonS3Service.downloadFile(memberProfileImagePath.getValue())) :
                         EmptyMemberProfileImageBytes.create();

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/mapper/supers/MemberProfileJpaMapper.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/mapper/supers/MemberProfileJpaMapper.java
@@ -8,5 +8,5 @@ import java.io.IOException;
 public interface MemberProfileJpaMapper {
     MemberProfileEntity toMemberProfileEntity(MemberProfile memberProfile);
 
-    MemberProfile toMemberProfile(MemberProfileEntity entity) throws IOException;
+    MemberProfile toMemberProfile(MemberProfileEntity entity, boolean needsImageBytes) throws IOException;
 }

--- a/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/repository/MemberProfileJpaRepository.java
+++ b/src/main/java/kr/modusplant/domains/member/framework/outbound/jpa/repository/MemberProfileJpaRepository.java
@@ -15,4 +15,6 @@ public interface MemberProfileJpaRepository extends
         LastModifiedAtRepository<MemberProfileEntity>,
         MemberUuidPrimaryKeyJpaRepository<MemberProfileEntity>,
         JpaRepository<MemberProfileEntity, UUID> {
+
+    boolean existsByImagePath(String imagePath);
 }

--- a/src/main/java/kr/modusplant/domains/member/usecase/port/repository/MemberProfileRepository.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/port/repository/MemberProfileRepository.java
@@ -8,9 +8,7 @@ import java.io.IOException;
 public interface MemberProfileRepository {
     MemberProfile getByIdWithoutImageBytes(MemberId memberId) throws IOException;
 
-    MemberProfile add(MemberProfile memberProfile) throws IOException;
-
-    MemberProfile update(MemberProfile memberProfile, boolean needsUntracking) throws IOException;
+    MemberProfile update(MemberProfile memberProfile, boolean needsUntracking, boolean needsImageBytes) throws IOException;
 
     boolean isIdExist(MemberId memberId);
 }

--- a/src/main/java/kr/modusplant/domains/member/usecase/port/repository/MemberProfileRepository.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/port/repository/MemberProfileRepository.java
@@ -2,6 +2,7 @@ package kr.modusplant.domains.member.usecase.port.repository;
 
 import kr.modusplant.domains.member.domain.aggregate.MemberProfile;
 import kr.modusplant.domains.member.domain.vo.MemberId;
+import kr.modusplant.domains.member.domain.vo.MemberProfileImagePath;
 
 import java.io.IOException;
 
@@ -11,4 +12,6 @@ public interface MemberProfileRepository {
     MemberProfile update(MemberProfile memberProfile, boolean needsUntracking, boolean needsImageBytes) throws IOException;
 
     boolean isIdExist(MemberId memberId);
+
+    boolean isImagePathExist(MemberProfileImagePath memberProfileImagePath);
 }

--- a/src/main/java/kr/modusplant/domains/member/usecase/port/repository/MemberProfileRepository.java
+++ b/src/main/java/kr/modusplant/domains/member/usecase/port/repository/MemberProfileRepository.java
@@ -2,7 +2,6 @@ package kr.modusplant.domains.member.usecase.port.repository;
 
 import kr.modusplant.domains.member.domain.aggregate.MemberProfile;
 import kr.modusplant.domains.member.domain.vo.MemberId;
-import kr.modusplant.domains.member.domain.vo.MemberProfileImagePath;
 
 import java.io.IOException;
 
@@ -12,6 +11,4 @@ public interface MemberProfileRepository {
     MemberProfile update(MemberProfile memberProfile, boolean needsUntracking, boolean needsImageBytes) throws IOException;
 
     boolean isIdExist(MemberId memberId);
-
-    boolean isImagePathExist(MemberProfileImagePath memberProfileImagePath);
 }

--- a/src/main/java/kr/modusplant/infrastructure/file/persistence/jpa/repository/PendingFileJpaRepository.java
+++ b/src/main/java/kr/modusplant/infrastructure/file/persistence/jpa/repository/PendingFileJpaRepository.java
@@ -16,6 +16,9 @@ public interface PendingFileJpaRepository extends JpaRepository<PendingFileEntit
     @Query("SELECT p.fileKey FROM PendingFileEntity p WHERE p.createdAt < :threshold")
     List<String> findFileKeysByCreatedAtBefore(@Param("threshold") LocalDateTime threshold);
 
+    @Query("SELECT p.fileKey FROM PendingFileEntity p WHERE p.fileKey IN :fileKeys")
+    List<String> findFileKeysByFileKeyIn(@Param("fileKeys") List<String> fileKeys);
+
     @Modifying
     @Query("DELETE FROM PendingFileEntity p WHERE p.createdAt < :threshold")
     void deleteByCreatedAtBefore(@Param("threshold") LocalDateTime threshold);

--- a/src/main/java/kr/modusplant/infrastructure/file/service/PendingFileService.java
+++ b/src/main/java/kr/modusplant/infrastructure/file/service/PendingFileService.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 /**
  * Presigned URL 기반 파일 업로드에서 고아파일(S3에는 있지만 DB에 파일키 등 메타데이터가 없는 파일)을 추적하고 정리하기 위한 전역 서비스.
- *
+ * <p>
  * 사용 도메인은 Presigned URL 발급 직후 {@link #trackPendingFiles}를,
  * 메타데이터 저장(또는 파일 교체 시 기존 fileKey) 성공 직후 {@link #untrackPendingFiles}를
  * 반드시 호출해야 고아파일 없이 정확하게 추적된다.

--- a/src/main/java/kr/modusplant/infrastructure/file/service/PendingFileService.java
+++ b/src/main/java/kr/modusplant/infrastructure/file/service/PendingFileService.java
@@ -59,8 +59,12 @@ public class PendingFileService {
     @Transactional
     public void untrackPendingFiles(List<String> fileKeys) {
         if (fileKeys == null || fileKeys.isEmpty()) return;
-        pendingFileJpaRepository.deleteByFileKeyIn(fileKeys);
-        log.debug("[PendingFile] Untracked {} file(s)", fileKeys.size());
+        List<String> existingFileKeys = pendingFileJpaRepository.findFileKeysByFileKeyIn(fileKeys);
+        pendingFileJpaRepository.deleteByFileKeyIn(existingFileKeys);
+        log.debug("[PendingFile] Untracked {} file(s)", existingFileKeys.size());
+        if (fileKeys.size() != existingFileKeys.size()) {
+            log.warn("[PendingFile] Skipped {} already untracked file(s)", fileKeys.size() - existingFileKeys.size());
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/modusplant/infrastructure/file/service/PendingFileService.java
+++ b/src/main/java/kr/modusplant/infrastructure/file/service/PendingFileService.java
@@ -32,14 +32,22 @@ public class PendingFileService {
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void trackPendingFiles(List<String> fileKeys) {
-        List<PendingFileEntity> entities = fileKeys.stream()
+        if (fileKeys == null || fileKeys.isEmpty()) return;
+        List<String> existingFileKeys = pendingFileJpaRepository.findFileKeysByFileKeyIn(fileKeys);
+        List<String> newFileKeys = fileKeys.stream()
+                .filter(fileKey -> !existingFileKeys.contains(fileKey))
+                .toList();
+        List<PendingFileEntity> entities = newFileKeys.stream()
                 .map(fileKey -> PendingFileEntity.builder()
                         .fileKey(fileKey)
                         .domain(extractDomain(fileKey))
                         .build())
                 .toList();
         pendingFileJpaRepository.saveAll(entities);
-        log.debug("[PendingFile] Tracked {} file(s)", fileKeys.size());
+        log.debug("[PendingFile] Tracked {} file(s)", newFileKeys.size());
+        if (fileKeys.size() != newFileKeys.size()) {
+            log.warn("[PendingFile] Skipped {} already tracked file(s)", fileKeys.size() - newFileKeys.size());
+        }
     }
 
     /**

--- a/src/main/java/kr/modusplant/shared/framework/aws/exception/enums/AWSErrorCode.java
+++ b/src/main/java/kr/modusplant/shared/framework/aws/exception/enums/AWSErrorCode.java
@@ -8,9 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AWSErrorCode implements ErrorCode {
-    NOT_FOUND_IMAGE_FILE_KEY(HttpStatus.BAD_REQUEST.value(), "not_found_image_file_key", "이미지 파일 키가 존재하지 않습니다. "),
-    NOT_FOUND_IMAGE_FILE_KEYS(HttpStatus.BAD_REQUEST.value(), "not_found_image_file_keys", "이미지 파일 키가 존재하지 않습니다. "),
-    NOT_FOUND_FILE_KEY_ON_S3(HttpStatus.INTERNAL_SERVER_ERROR.value(), "not_found_file_key_on_s3", "Amazon S3에서 파일 키를 찾을 수 없습니다. ");
+    NOT_FOUND_IMAGE_FILE_KEY(HttpStatus.NOT_FOUND.value(), "not_found_image_file_key", "이미지 파일 키가 존재하지 않습니다. "),
+    NOT_FOUND_IMAGE_FILE_KEYS(HttpStatus.NOT_FOUND.value(), "not_found_image_file_keys", "이미지 파일 키가 존재하지 않습니다. "),
+    NOT_FOUND_FILE_KEY_ON_S3(HttpStatus.NOT_FOUND.value(), "not_found_file_key_on_s3", "Amazon S3에서 파일 키를 찾을 수 없습니다. ");
 
     private final int httpStatus;
     private final String code;

--- a/src/main/java/kr/modusplant/shared/framework/aws/service/AmazonS3Service.java
+++ b/src/main/java/kr/modusplant/shared/framework/aws/service/AmazonS3Service.java
@@ -63,7 +63,6 @@ public class AmazonS3Service {
         }
     }
 
-
     public void deleteFile(String fileKey) {
         DeleteObjectRequest request = DeleteObjectRequest.builder()
                 .bucket(bucket)
@@ -128,5 +127,19 @@ public class AmazonS3Service {
 
         PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(presignRequest);
         return presignedPutObjectRequest.url().toString();
+    }
+
+    public boolean checkIfFileExists(String fileKey) {
+        HeadObjectRequest request = HeadObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileKey)
+                .build();
+
+        try {
+            s3Client.headObject(request);
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
     }
 }

--- a/src/main/resources/db/migration/schema/V5.1.1__Alter_image_number_of_prop_bug_rep_to_allow_by_three.sql
+++ b/src/main/resources/db/migration/schema/V5.1.1__Alter_image_number_of_prop_bug_rep_to_allow_by_three.sql
@@ -1,0 +1,26 @@
+-- 1. 기존 데이터의 image_number 값을 image 배열 길이에 맞춰 재계산
+UPDATE public.prop_bug_rep
+SET image_number = CASE
+    WHEN image IS NULL THEN NULL
+    ELSE jsonb_array_length(image)
+END;
+
+-- 2. image 변경 시 image_number를 자동으로 갱신하는 트리거 함수
+CREATE OR REPLACE FUNCTION fn_update_prop_bug_rep_image_number()
+    RETURNS TRIGGER AS
+$$
+BEGIN
+    NEW.image_number := CASE
+        WHEN NEW.image IS NULL THEN NULL
+        ELSE jsonb_array_length(NEW.image)
+    END;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. 트리거 등록
+CREATE OR REPLACE TRIGGER trg_prop_bug_rep_image_number
+    BEFORE INSERT OR UPDATE OF image
+    ON public.prop_bug_rep
+    FOR EACH ROW
+EXECUTE FUNCTION fn_update_prop_bug_rep_image_number();

--- a/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberControllerTest.java
@@ -468,6 +468,7 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
         given(swearService.filterSwear(any())).willReturn(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
+        given(memberProfileRepository.isImagePathExist(any())).willReturn(true);
         given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
@@ -485,6 +486,7 @@ class MemberControllerTest implements
         MemberProfile memberProfile = MemberProfile.create(testMemberId, EmptyMemberProfileImage.create(), EmptyMemberProfileIntroduction.create(), testNormalUserNickname);
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
+        given(memberProfileRepository.isImagePathExist(any())).willReturn(true);
         given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
@@ -507,6 +509,7 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
         given(swearService.filterSwear(any())).willReturn(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
+        given(memberProfileRepository.isImagePathExist(any())).willReturn(true);
         given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
@@ -524,6 +527,7 @@ class MemberControllerTest implements
         MemberProfile memberProfile = MemberProfile.create(testMemberId, EmptyMemberProfileImage.create(), EmptyMemberProfileIntroduction.create(), testNormalUserNickname);
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
+        given(memberProfileRepository.isImagePathExist(any())).willReturn(true);
         given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
@@ -617,6 +621,21 @@ class MemberControllerTest implements
     }
 
     @Test
+    @DisplayName("존재하지 않는 이미지 경로로 인해 overrideProfile V2로 프로필 덮어쓰기 실패")
+    void testValidateThatImagePathNotExistsV2_willThrowException() {
+        // given
+        willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
+        given(swearService.isSwearContained(any())).willReturn(false);
+        given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
+        given(memberProfileRepository.isImagePathExist(any())).willReturn(false);
+
+        // when & then
+        NotFoundEntityException notFoundEntityException = assertThrows(
+                NotFoundEntityException.class, () -> memberController.overrideProfile(testMemberProfileOverrideRecordV2));
+        assertThat(notFoundEntityException.getErrorCode()).isEqualTo(NOT_FOUND_MEMBER_PROFILE);
+    }
+
+    @Test
     @DisplayName("존재하지 않는 아이디로 인해 overrideProfile V3로 프로필 덮어쓰기 실패")
     void testValidateMemberIdAndNicknameBeforeOverrideProfileV3_givenNotFoundId_willThrowException() {
         // given
@@ -653,6 +672,21 @@ class MemberControllerTest implements
         ExistsEntityException existsEntityException = assertThrows(
                 ExistsEntityException.class, () -> memberController.overrideProfile(testMemberProfileOverrideRecordV3));
         assertThat(existsEntityException.getErrorCode()).isEqualTo(KernelErrorCode.EXISTS_NICKNAME);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이미지 경로로 인해 overrideProfile V3로 프로필 덮어쓰기 실패")
+    void testValidateThatImagePathNotExistsV3_willThrowException() {
+        // given
+        willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
+        given(swearService.isSwearContained(any())).willReturn(false);
+        given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
+        given(memberProfileRepository.isImagePathExist(any())).willReturn(false);
+
+        // when & then
+        NotFoundEntityException notFoundEntityException = assertThrows(
+                NotFoundEntityException.class, () -> memberController.overrideProfile(testMemberProfileOverrideRecordV3));
+        assertThat(notFoundEntityException.getErrorCode()).isEqualTo(NOT_FOUND_MEMBER_PROFILE);
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberControllerTest.java
@@ -231,7 +231,7 @@ class MemberControllerTest implements
         assertThat(memberProfilePrepareResponse).isEqualTo(testMemberProfilePrepareResponse);
         verify(memberImageIOHelper).deleteImage(originalMemberProfileImage);
         assertThat(memberProfile.getMemberProfileImage()).isEqualTo(testEmptyMemberProfileImage);
-        verify(memberProfileRepository, times(1)).update(memberProfile, false);
+        verify(memberProfileRepository, times(1)).update(memberProfile, false, false);
     }
 
     @Test
@@ -253,7 +253,7 @@ class MemberControllerTest implements
         assertThat(memberProfilePrepareResponse).isEqualTo(testMemberProfilePrepareResponse);
         verify(memberImageIOHelper).deleteImage(originalMemberProfileImage);
         assertThat(memberProfile.getMemberProfileImage()).isEqualTo(testEmptyMemberProfileImage);
-        verify(memberProfileRepository, times(1)).update(memberProfile, false);
+        verify(memberProfileRepository, times(1)).update(memberProfile, false, false);
     }
 
     @Test
@@ -393,7 +393,7 @@ class MemberControllerTest implements
         given(swearService.filterSwear(any())).willReturn(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
         willDoNothing().given(memberImageIOHelper).deleteImage(any());
         given(memberImageIOHelper.uploadImage(any(MemberId.class), any(MemberProfileOverrideRecord_V1.class))).willReturn(MEMBER_PROFILE_BASIC_USER_IMAGE_PATH);
-        given(memberProfileRepository.update(any(), eq(false))).willReturn(memberProfile);
+        given(memberProfileRepository.update(any(), eq(false), eq(true))).willReturn(memberProfile);
         given(amazonS3Service.generateS3SrcUrl(any())).willReturn(MEMBER_PROFILE_BASIC_USER_IMAGE_URL);
 
         // when
@@ -404,7 +404,7 @@ class MemberControllerTest implements
         assertThat(memberProfileResponseWithImageUrl.imageUrl()).isEqualTo(MEMBER_PROFILE_BASIC_USER_IMAGE_URL);
         assertThat(memberProfileResponseWithImageUrl.introduction()).isEqualTo(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
         assertThat(memberProfileResponseWithImageUrl.nickname()).isEqualTo(MEMBER_BASIC_USER_NICKNAME);
-        verify(memberProfileRepository, times(1)).update(any(), eq(false));
+        verify(memberProfileRepository, times(1)).update(any(), eq(false), eq(true));
     }
 
     @Test
@@ -423,7 +423,7 @@ class MemberControllerTest implements
         given(swearService.filterSwear(any())).willReturn(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
         willDoNothing().given(memberImageIOHelper).deleteImage(any());
         given(memberImageIOHelper.uploadImage(any(MemberId.class), any(MemberProfileOverrideRecord_V1.class))).willReturn(MEMBER_PROFILE_BASIC_USER_IMAGE_PATH);
-        given(memberProfileRepository.update(any(), eq(false))).willReturn(memberProfile);
+        given(memberProfileRepository.update(any(), eq(false), eq(true))).willReturn(memberProfile);
         given(amazonS3Service.generateS3SrcUrl(any())).willReturn(MEMBER_PROFILE_BASIC_USER_IMAGE_URL);
 
         // when
@@ -434,7 +434,7 @@ class MemberControllerTest implements
         assertThat(memberProfileResponseWithImageUrl.imageUrl()).isEqualTo(MEMBER_PROFILE_BASIC_USER_IMAGE_URL);
         assertThat(memberProfileResponseWithImageUrl.introduction()).isEqualTo(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
         assertThat(memberProfileResponseWithImageUrl.nickname()).isEqualTo(MEMBER_BASIC_USER_NICKNAME);
-        verify(memberProfileRepository, times(1)).update(any(), eq(false));
+        verify(memberProfileRepository, times(1)).update(any(), eq(false), eq(true));
     }
 
     @Test
@@ -445,7 +445,7 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
         given(memberProfileRepository.getByIdWithoutImageBytes(any())).willReturn(memberProfile);
-        given(memberProfileRepository.update(any(), eq(false))).willReturn(memberProfile);
+        given(memberProfileRepository.update(any(), eq(false), eq(true))).willReturn(memberProfile);
         willDoNothing().given(memberImageIOHelper).deleteImage(any());
 
         // when
@@ -457,7 +457,7 @@ class MemberControllerTest implements
         assertThat(memberProfileResponseWithImageUrl.imageUrl()).isEqualTo(null);
         assertThat(memberProfileResponseWithImageUrl.introduction()).isEqualTo(null);
         assertThat(memberProfileResponseWithImageUrl.nickname()).isEqualTo(MEMBER_BASIC_USER_NICKNAME);
-        verify(memberProfileRepository, times(1)).update(any(), eq(false));
+        verify(memberProfileRepository, times(1)).update(any(), eq(false), eq(true));
     }
 
     @Test
@@ -468,14 +468,14 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
         given(swearService.filterSwear(any())).willReturn(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
-        given(memberProfileRepository.update(any(), eq(true))).willReturn(memberProfile);
+        given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
         MemberProfileResponseWithImageUrl memberProfileResponseWithImageUrl = memberController.overrideProfile(testMemberProfileOverrideRecordV2);
 
         // then
         assertThat(memberProfileResponseWithImageUrl).isEqualTo(testMemberProfileResponseWithImageUrlV2);
-        verify(memberProfileRepository, times(1)).update(any(), eq(true));
+        verify(memberProfileRepository, times(1)).update(any(), eq(true), eq(false));
     }
 
     @Test
@@ -485,7 +485,7 @@ class MemberControllerTest implements
         MemberProfile memberProfile = MemberProfile.create(testMemberId, EmptyMemberProfileImage.create(), EmptyMemberProfileIntroduction.create(), testNormalUserNickname);
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
-        given(memberProfileRepository.update(any(), eq(true))).willReturn(memberProfile);
+        given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
         MemberProfileResponseWithImageUrl memberProfileResponseWithImageUrl = memberController.overrideProfile(
@@ -496,7 +496,7 @@ class MemberControllerTest implements
         assertThat(memberProfileResponseWithImageUrl.imageUrl()).isEqualTo(null);
         assertThat(memberProfileResponseWithImageUrl.introduction()).isEqualTo(null);
         assertThat(memberProfileResponseWithImageUrl.nickname()).isEqualTo(MEMBER_BASIC_USER_NICKNAME);
-        verify(memberProfileRepository, times(1)).update(any(), eq(true));
+        verify(memberProfileRepository, times(1)).update(any(), eq(true), eq(false));
     }
 
     @Test
@@ -507,14 +507,14 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
         given(swearService.filterSwear(any())).willReturn(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
-        given(memberProfileRepository.update(any(), eq(true))).willReturn(memberProfile);
+        given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
         MemberProfileResponseWithImagePath memberProfileResponseWithImagePath = memberController.overrideProfile(testMemberProfileOverrideRecordV3);
 
         // then
         assertThat(memberProfileResponseWithImagePath).isEqualTo(testMemberProfileResponseWithImagePathV3);
-        verify(memberProfileRepository, times(1)).update(any(), eq(true));
+        verify(memberProfileRepository, times(1)).update(any(), eq(true), eq(false));
     }
 
     @Test
@@ -524,7 +524,7 @@ class MemberControllerTest implements
         MemberProfile memberProfile = MemberProfile.create(testMemberId, EmptyMemberProfileImage.create(), EmptyMemberProfileIntroduction.create(), testNormalUserNickname);
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
-        given(memberProfileRepository.update(any(), eq(true))).willReturn(memberProfile);
+        given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
         MemberProfileResponseWithImagePath memberProfileResponseWithImagePath = memberController.overrideProfile(
@@ -535,7 +535,7 @@ class MemberControllerTest implements
         assertThat(memberProfileResponseWithImagePath.imagePath()).isEqualTo(null);
         assertThat(memberProfileResponseWithImagePath.introduction()).isEqualTo(null);
         assertThat(memberProfileResponseWithImagePath.nickname()).isEqualTo(MEMBER_BASIC_USER_NICKNAME);
-        verify(memberProfileRepository, times(1)).update(any(), eq(true));
+        verify(memberProfileRepository, times(1)).update(any(), eq(true), eq(false));
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberControllerTest.java
+++ b/src/test/java/kr/modusplant/domains/member/adapter/controller/MemberControllerTest.java
@@ -48,6 +48,8 @@ import kr.modusplant.shared.enums.Role;
 import kr.modusplant.shared.exception.EmptyValueException;
 import kr.modusplant.shared.exception.InvalidValueException;
 import kr.modusplant.shared.exception.NotAccessibleException;
+import kr.modusplant.shared.framework.aws.exception.NotFoundFileKeyOnS3Exception;
+import kr.modusplant.shared.framework.aws.exception.enums.AWSErrorCode;
 import kr.modusplant.shared.framework.aws.service.AmazonS3Service;
 import kr.modusplant.shared.framework.jackson.holder.ObjectMapperHolder;
 import kr.modusplant.shared.framework.jpa.exception.ExistsEntityException;
@@ -468,7 +470,7 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
         given(swearService.filterSwear(any())).willReturn(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
-        given(memberProfileRepository.isImagePathExist(any())).willReturn(true);
+        willDoNothing().given(memberImageIOHelper).validateIfImageExists(any());
         given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
@@ -486,7 +488,7 @@ class MemberControllerTest implements
         MemberProfile memberProfile = MemberProfile.create(testMemberId, EmptyMemberProfileImage.create(), EmptyMemberProfileIntroduction.create(), testNormalUserNickname);
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
-        given(memberProfileRepository.isImagePathExist(any())).willReturn(true);
+        willDoNothing().given(memberImageIOHelper).validateIfImageExists(any());
         given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
@@ -509,7 +511,7 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
         given(swearService.filterSwear(any())).willReturn(MEMBER_PROFILE_BASIC_USER_INTRODUCTION);
-        given(memberProfileRepository.isImagePathExist(any())).willReturn(true);
+        willDoNothing().given(memberImageIOHelper).validateIfImageExists(any());
         given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
@@ -527,7 +529,7 @@ class MemberControllerTest implements
         MemberProfile memberProfile = MemberProfile.create(testMemberId, EmptyMemberProfileImage.create(), EmptyMemberProfileIntroduction.create(), testNormalUserNickname);
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
-        given(memberProfileRepository.isImagePathExist(any())).willReturn(true);
+        willDoNothing().given(memberImageIOHelper).validateIfImageExists(any());
         given(memberProfileRepository.update(any(), eq(true), eq(false))).willReturn(memberProfile);
 
         // when
@@ -627,12 +629,12 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(swearService.isSwearContained(any())).willReturn(false);
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
-        given(memberProfileRepository.isImagePathExist(any())).willReturn(false);
+        willThrow(new NotFoundFileKeyOnS3Exception()).given(memberImageIOHelper).validateIfImageExists(any());
 
         // when & then
-        NotFoundEntityException notFoundEntityException = assertThrows(
-                NotFoundEntityException.class, () -> memberController.overrideProfile(testMemberProfileOverrideRecordV2));
-        assertThat(notFoundEntityException.getErrorCode()).isEqualTo(NOT_FOUND_MEMBER_PROFILE);
+        NotFoundFileKeyOnS3Exception notFoundFileKeyOnS3Exception = assertThrows(
+                NotFoundFileKeyOnS3Exception.class, () -> memberController.overrideProfile(testMemberProfileOverrideRecordV2));
+        assertThat(notFoundFileKeyOnS3Exception.getErrorCode()).isEqualTo(AWSErrorCode.NOT_FOUND_FILE_KEY_ON_S3);
     }
 
     @Test
@@ -681,12 +683,12 @@ class MemberControllerTest implements
         willDoNothing().given(memberValidationHelper).validateIfMemberExists(any());
         given(swearService.isSwearContained(any())).willReturn(false);
         given(memberRepository.getByNickname(any())).willReturn(Optional.empty());
-        given(memberProfileRepository.isImagePathExist(any())).willReturn(false);
+        willThrow(new NotFoundFileKeyOnS3Exception()).given(memberImageIOHelper).validateIfImageExists(any());
 
         // when & then
-        NotFoundEntityException notFoundEntityException = assertThrows(
-                NotFoundEntityException.class, () -> memberController.overrideProfile(testMemberProfileOverrideRecordV3));
-        assertThat(notFoundEntityException.getErrorCode()).isEqualTo(NOT_FOUND_MEMBER_PROFILE);
+        NotFoundFileKeyOnS3Exception notFoundFileKeyOnS3Exception = assertThrows(
+                NotFoundFileKeyOnS3Exception.class, () -> memberController.overrideProfile(testMemberProfileOverrideRecordV3));
+        assertThat(notFoundFileKeyOnS3Exception.getErrorCode()).isEqualTo(AWSErrorCode.NOT_FOUND_FILE_KEY_ON_S3);
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/adapter/helper/MemberImageIOHelperTest.java
+++ b/src/test/java/kr/modusplant/domains/member/adapter/helper/MemberImageIOHelperTest.java
@@ -1,6 +1,8 @@
 package kr.modusplant.domains.member.adapter.helper;
 
 import kr.modusplant.infrastructure.file.service.PendingFileService;
+import kr.modusplant.shared.framework.aws.exception.NotFoundFileKeyOnS3Exception;
+import kr.modusplant.shared.framework.aws.exception.enums.AWSErrorCode;
 import kr.modusplant.shared.framework.aws.service.AmazonS3Service;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,11 +22,14 @@ import static kr.modusplant.domains.member.common.util.domain.vo.MemberIdTestUti
 import static kr.modusplant.domains.member.common.util.domain.vo.MemberProfileImagePathTestUtils.testMemberProfileImagePath;
 import static kr.modusplant.domains.member.common.util.domain.vo.ReportIdTestUtils.testReportId;
 import static kr.modusplant.domains.member.common.util.domain.vo.ReportImagePathTestUtils.testReportImagePath1;
+import static kr.modusplant.domains.member.common.util.domain.vo.nullobject.EmptyMemberProfileImagePathTestUtils.testEmptyMemberProfileImagePath;
 import static kr.modusplant.domains.member.common.util.usecase.record.MemberProfileOverrideRecordTestUtils.testMemberProfileOverrideRecordV1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -88,5 +93,41 @@ class MemberImageIOHelperTest {
         // then
         assertThat(storageUrl).isEqualTo(TEST_REPORT_PROPOSAL_OR_BUG_IMAGE_STORAGE_URL_1);
         verify(pendingFileService, times(1)).trackPendingFiles(List.of(testReportImagePath1.getValue()));
+    }
+
+    @Test
+    @DisplayName("존재하는 이미지 경로로 validateIfImageExists 검증 활동 수행")
+    void testValidateIfImageExists_givenExistingImagePath_willProcessAction() {
+        // given
+        given(amazonS3Service.checkIfFileExists(testMemberProfileImagePath.getValue())).willReturn(true);
+
+        // when
+        memberImageIOHelper.validateIfImageExists(testMemberProfileImagePath);
+
+        // then
+        verify(amazonS3Service, times(1)).checkIfFileExists(testMemberProfileImagePath.getValue());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이미지 경로로 validateIfImageExists 검증 예외 반환")
+    void testValidateIfImageExists_givenNonExistingImagePath_willThrowException() {
+        // given
+        given(amazonS3Service.checkIfFileExists(testMemberProfileImagePath.getValue())).willReturn(false);
+
+        // when & then
+        NotFoundFileKeyOnS3Exception notFoundFileKeyOnS3Exception = assertThrows(
+                NotFoundFileKeyOnS3Exception.class,
+                () -> memberImageIOHelper.validateIfImageExists(testMemberProfileImagePath));
+        assertThat(notFoundFileKeyOnS3Exception.getErrorCode()).isEqualTo(AWSErrorCode.NOT_FOUND_FILE_KEY_ON_S3);
+    }
+
+    @Test
+    @DisplayName("null 이미지 경로로 validateIfImageExists 검증 활동 수행")
+    void testValidateIfImageExists_givenNullImagePath_willProcessAction() {
+        // given & when
+        memberImageIOHelper.validateIfImageExists(testEmptyMemberProfileImagePath);
+
+        // then
+        verify(amazonS3Service, never()).checkIfFileExists(any());
     }
 }

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapterTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapterTest.java
@@ -92,8 +92,8 @@ class MemberProfileRepositoryJpaAdapterTest implements
         given(amazonS3Service.downloadFile(any())).willReturn(MEMBER_PROFILE_BASIC_USER_IMAGE_BYTES);
 
         // when
-        MemberProfile updatedMemberProfile = memberProfileJpaMapper.toMemberProfile(updatedMemberProfileEntity);
-        MemberProfile result = memberProfileRepositoryJpaAdapter.update(updatedMemberProfile, false);
+        MemberProfile updatedMemberProfile = memberProfileJpaMapper.toMemberProfile(updatedMemberProfileEntity, true);
+        MemberProfile result = memberProfileRepositoryJpaAdapter.update(updatedMemberProfile, false, true);
 
         // then
         assertThat(result.getNickname().getValue()).isEqualTo("abcNickname");
@@ -116,13 +116,34 @@ class MemberProfileRepositoryJpaAdapterTest implements
         willDoNothing().given(pendingFileService).untrackPendingFiles(any());
 
         // when
-        MemberProfile updatedMemberProfile = memberProfileJpaMapper.toMemberProfile(updatedMemberProfileEntity);
-        MemberProfile result = memberProfileRepositoryJpaAdapter.update(updatedMemberProfile, true);
+        MemberProfile updatedMemberProfile = memberProfileJpaMapper.toMemberProfile(updatedMemberProfileEntity, true);
+        MemberProfile result = memberProfileRepositoryJpaAdapter.update(updatedMemberProfile, true, true);
 
         // then
         assertThat(result.getNickname().getValue()).isEqualTo("abcNickname");
         assertThat(result.getMemberProfileIntroduction().getValue()).isEqualTo("abcIntroduction");
         verify(pendingFileService, times(1)).untrackPendingFiles(List.of(updatedMemberProfileEntity.getImagePath()));
+    }
+
+    @Test
+    @DisplayName("needsImageBytes가 false로 update 실행 시 이미지 다운로드 없이 MemberProfile 반환")
+    void testUpdate_givenNeedsImageBytesFalse_willReturnMemberProfileWithoutDownloadingImage() throws IOException {
+        // given
+        MemberEntity memberEntity = createMemberBasicUserEntityWithUuid();
+        MemberProfileEntity memberProfileEntity = createMemberProfileBasicUserEntityBuilder().member(memberEntity).build();
+        MemberEntity updatedMemberEntity = MemberEntity.builder().member(memberEntity).nickname("abcNickname").build();
+        MemberProfileEntity updatedMemberProfileEntity =
+                MemberProfileEntity.builder().member(updatedMemberEntity).introduction("abcIntroduction").imagePath(MEMBER_PROFILE_BASIC_USER_IMAGE_PATH).build();
+        given(memberProfileJpaRepository.findByUuid(any())).willReturn(Optional.of(memberProfileEntity));
+        given(memberProfileJpaRepository.save(updatedMemberProfileEntity)).willReturn(updatedMemberProfileEntity);
+
+        // when
+        MemberProfile updatedMemberProfile = memberProfileJpaMapper.toMemberProfile(updatedMemberProfileEntity, false);
+        MemberProfile result = memberProfileRepositoryJpaAdapter.update(updatedMemberProfile, false, false);
+
+        // then
+        assertThat(result.getMemberProfileImage().getMemberProfileImageBytes().getValue()).isNull();
+        verify(amazonS3Service, never()).downloadFile(any());
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapterTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapterTest.java
@@ -40,7 +40,7 @@ class MemberProfileRepositoryJpaAdapterTest implements
     private final MemberJpaRepository memberJpaRepository = Mockito.mock(MemberJpaRepository.class);
     private final MemberProfileJpaRepository memberProfileJpaRepository = Mockito.mock(MemberProfileJpaRepository.class);
     private final MemberProfileJpaMapperImpl memberProfileJpaMapper = new MemberProfileJpaMapperImpl(memberJpaRepository, amazonS3Service);
-    private final MemberProfileRepositoryJpaAdapter memberProfileRepositoryJpaAdapter = new MemberProfileRepositoryJpaAdapter(pendingFileService, memberProfileJpaMapper, memberJpaRepository, memberProfileJpaRepository);
+    private final MemberProfileRepositoryJpaAdapter memberProfileRepositoryJpaAdapter = new MemberProfileRepositoryJpaAdapter(pendingFileService, memberProfileJpaMapper, memberProfileJpaRepository);
 
     @Test
     @DisplayName("선택적인 데이터가 모두 있을 때 getByIdWithoutImageBytes로 가용한 MemberProfile 반환(가용할 때)")
@@ -76,23 +76,6 @@ class MemberProfileRepositoryJpaAdapterTest implements
 
         // then
         assertThrows(NotFoundEntityException.class, () -> memberProfileRepositoryJpaAdapter.getByIdWithoutImageBytes(testMemberId));
-    }
-
-    @Test
-    @DisplayName("add로 MemberProfile 반환")
-    void testAdd_givenValidMemberProfile_willReturnMemberProfile() throws IOException {
-        // given
-        MemberEntity memberBasicUserEntity = createMemberBasicUserEntityWithUuid();
-        MemberProfileEntity memberProfileEntity = createMemberProfileBasicUserEntityBuilder().member(memberBasicUserEntity).build();
-        given(memberJpaRepository.findByUuid(any())).willReturn(Optional.of(memberBasicUserEntity));
-        given(memberProfileJpaRepository.save(memberProfileEntity)).willReturn(memberProfileEntity);
-        given(amazonS3Service.downloadFile(any())).willReturn(MEMBER_PROFILE_BASIC_USER_IMAGE_BYTES);
-
-        // when
-        MemberProfile memberProfile = createMemberProfile();
-
-        // then
-        assertThat(memberProfileRepositoryJpaAdapter.add(memberProfile)).isEqualTo(memberProfile);
     }
 
     @Test

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapterTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapterTest.java
@@ -1,7 +1,6 @@
 package kr.modusplant.domains.member.framework.outbound.jpa.adapter;
 
 import kr.modusplant.domains.member.common.util.domain.aggregate.MemberProfileTestUtils;
-import kr.modusplant.domains.member.common.util.domain.vo.MemberProfileImagePathTestUtils;
 import kr.modusplant.domains.member.common.util.framework.outbound.jpa.entity.MemberEntityTestUtils;
 import kr.modusplant.domains.member.common.util.framework.outbound.jpa.entity.MemberProfileEntityTestUtils;
 import kr.modusplant.domains.member.domain.aggregate.MemberProfile;
@@ -34,7 +33,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class MemberProfileRepositoryJpaAdapterTest implements
-        MemberProfileTestUtils, MemberProfileImagePathTestUtils,
+        MemberProfileTestUtils,
         MemberEntityTestUtils, MemberProfileEntityTestUtils {
     private final AmazonS3Service amazonS3Service = Mockito.mock(AmazonS3Service.class);
     private final PendingFileService pendingFileService = Mockito.mock(PendingFileService.class);
@@ -165,25 +164,5 @@ class MemberProfileRepositoryJpaAdapterTest implements
 
         // when & then
         assertThat(memberProfileRepositoryJpaAdapter.isIdExist(testMemberId)).isEqualTo(false);
-    }
-
-    @Test
-    @DisplayName("isImagePathExist로 true 반환")
-    void testIsImagePathExist_givenPathThatExists_willReturnTrue() {
-        // given & when
-        given(memberProfileJpaRepository.existsByImagePath(testMemberProfileImagePath.getValue())).willReturn(true);
-
-        // when & then
-        assertThat(memberProfileRepositoryJpaAdapter.isImagePathExist(testMemberProfileImagePath)).isEqualTo(true);
-    }
-
-    @Test
-    @DisplayName("isImagePathExist로 false 반환")
-    void testIsImagePathExist_givenPathThatIsNotExist_willReturnFalse() {
-        // given & when
-        given(memberProfileJpaRepository.existsByImagePath(testMemberProfileImagePath.getValue())).willReturn(false);
-
-        // when & then
-        assertThat(memberProfileRepositoryJpaAdapter.isImagePathExist(testMemberProfileImagePath)).isEqualTo(false);
     }
 }

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapterTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/adapter/MemberProfileRepositoryJpaAdapterTest.java
@@ -1,6 +1,7 @@
 package kr.modusplant.domains.member.framework.outbound.jpa.adapter;
 
 import kr.modusplant.domains.member.common.util.domain.aggregate.MemberProfileTestUtils;
+import kr.modusplant.domains.member.common.util.domain.vo.MemberProfileImagePathTestUtils;
 import kr.modusplant.domains.member.common.util.framework.outbound.jpa.entity.MemberEntityTestUtils;
 import kr.modusplant.domains.member.common.util.framework.outbound.jpa.entity.MemberProfileEntityTestUtils;
 import kr.modusplant.domains.member.domain.aggregate.MemberProfile;
@@ -33,7 +34,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class MemberProfileRepositoryJpaAdapterTest implements
-        MemberProfileTestUtils,
+        MemberProfileTestUtils, MemberProfileImagePathTestUtils,
         MemberEntityTestUtils, MemberProfileEntityTestUtils {
     private final AmazonS3Service amazonS3Service = Mockito.mock(AmazonS3Service.class);
     private final PendingFileService pendingFileService = Mockito.mock(PendingFileService.class);
@@ -164,5 +165,25 @@ class MemberProfileRepositoryJpaAdapterTest implements
 
         // when & then
         assertThat(memberProfileRepositoryJpaAdapter.isIdExist(testMemberId)).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("isImagePathExist로 true 반환")
+    void testIsImagePathExist_givenPathThatExists_willReturnTrue() {
+        // given & when
+        given(memberProfileJpaRepository.existsByImagePath(testMemberProfileImagePath.getValue())).willReturn(true);
+
+        // when & then
+        assertThat(memberProfileRepositoryJpaAdapter.isImagePathExist(testMemberProfileImagePath)).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("isImagePathExist로 false 반환")
+    void testIsImagePathExist_givenPathThatIsNotExist_willReturnFalse() {
+        // given & when
+        given(memberProfileJpaRepository.existsByImagePath(testMemberProfileImagePath.getValue())).willReturn(false);
+
+        // when & then
+        assertThat(memberProfileRepositoryJpaAdapter.isImagePathExist(testMemberProfileImagePath)).isEqualTo(false);
     }
 }

--- a/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/mapper/MemberProfileJpaMapperImplTest.java
+++ b/src/test/java/kr/modusplant/domains/member/framework/outbound/jpa/mapper/MemberProfileJpaMapperImplTest.java
@@ -25,6 +25,9 @@ import static kr.modusplant.shared.kernel.common.util.NicknameTestUtils.testNorm
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 class MemberProfileJpaMapperImplTest implements
         MemberTestUtils, MemberProfileTestUtils,
@@ -50,13 +53,29 @@ class MemberProfileJpaMapperImplTest implements
     }
 
     @Test
-    @DisplayName("toMemberProfile로 회원 반환")
-    void testToMemberProfile_givenValidMemberProfileEntity_willReturnMemberProfile() throws IOException {
+    @DisplayName("needsImageBytes가 true로 toMemberProfile로 회원 반환")
+    void testToMemberProfile_givenNeedsImageBytesTrue_willReturnMemberProfile() throws IOException {
         // given & when
         given(amazonS3Service.downloadFile(any())).willReturn(MEMBER_PROFILE_BASIC_USER_IMAGE_BYTES);
 
+        MemberProfile result = memberProfileJpaMapper.toMemberProfile(
+                createMemberProfileBasicUserEntityBuilder().member(createMemberBasicUserEntityWithUuid()).build(), true);
+
         // then
-        assertThat(memberProfileJpaMapper.toMemberProfile(createMemberProfileBasicUserEntityBuilder().member(createMemberBasicUserEntityWithUuid()).build())).isEqualTo(createMemberProfile());
+        assertThat(result).isEqualTo(createMemberProfile());
+        verify(amazonS3Service, times(1)).downloadFile(any());
+    }
+
+    @Test
+    @DisplayName("needsImageBytes가 false로 toMemberProfile로 이미지 바이트가 없는 회원 반환")
+    void testToMemberProfile_givenNeedsImageBytesFalse_willReturnMemberProfile() throws IOException {
+        // given & when
+        MemberProfile result = memberProfileJpaMapper.toMemberProfile(
+                createMemberProfileBasicUserEntityBuilder().member(createMemberBasicUserEntityWithUuid()).build(), false);
+
+        // then
+        assertThat(result.getMemberProfileImage().getMemberProfileImageBytes().getValue()).isNull();
+        verify(amazonS3Service, never()).downloadFile(any());
     }
 
     @Test
@@ -67,7 +86,7 @@ class MemberProfileJpaMapperImplTest implements
                         .member(createMemberBasicUserEntityWithUuid())
                         .imagePath(null)
                         .introduction(null)
-                        .build()))
+                        .build(), true))
                 .isEqualTo(MemberProfile.create(
                         testMemberId,
                         EmptyMemberProfileImage.create(),

--- a/src/test/java/kr/modusplant/infrastructure/file/persistence/jpa/repository/PendingFileJpaRepositoryTest.java
+++ b/src/test/java/kr/modusplant/infrastructure/file/persistence/jpa/repository/PendingFileJpaRepositoryTest.java
@@ -80,6 +80,34 @@ class PendingFileJpaRepositoryTest implements PendingFileEntityTestUtils {
         assertThat(pendingFileRepository.existsById(pendingFile.getUlid())).isTrue();
     }
 
+    @DisplayName("fileKey 목록에 해당하는 존재하는 fileKey 조회")
+    @Test
+    void testFindFileKeysByFileKeyIn_givenExistingFileKeys_willReturnFileKeys() {
+        // given
+        PendingFileEntity target = pendingFileRepository.saveAndFlush(createPostPendingFileEntity());
+        PendingFileEntity other = pendingFileRepository.saveAndFlush(createPostPendingFileEntity(TEST_MEMBER_PROFILE_FILE_KEY, TEST_MEMBER_DOMAIN));
+
+        // when
+        List<String> fileKeys = pendingFileRepository.findFileKeysByFileKeyIn(List.of(target.getFileKey()));
+
+        // then
+        assertThat(fileKeys).containsExactly(target.getFileKey());
+        assertThat(fileKeys).doesNotContain(other.getFileKey());
+    }
+
+    @DisplayName("목록에 없는 fileKey는 조회되지 않음")
+    @Test
+    void testFindFileKeysByFileKeyIn_givenNonExistingFileKey_willReturnEmptyList() {
+        // given
+        pendingFileRepository.saveAndFlush(createPostPendingFileEntity());
+
+        // when
+        List<String> fileKeys = pendingFileRepository.findFileKeysByFileKeyIn(List.of(TEST_MEMBER_PROFILE_FILE_KEY));
+
+        // then
+        assertThat(fileKeys).isEmpty();
+    }
+
     @DisplayName("fileKey 목록으로 레코드 삭제")
     @Test
     void testDeleteByFileKeyIn_givenFileKeys_willDeletePendingFiles() {

--- a/src/test/java/kr/modusplant/infrastructure/file/service/PendingFileServiceTest.java
+++ b/src/test/java/kr/modusplant/infrastructure/file/service/PendingFileServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static kr.modusplant.infrastructure.file.common.constant.PendingFileConstant.TEST_MEMBER_PROFILE_FILE_KEY;
 import static kr.modusplant.infrastructure.file.common.constant.PendingFileConstant.TEST_POST_CONTENT_FILE_KEY;
 import static kr.modusplant.infrastructure.file.common.constant.PendingFileConstant.TEST_POST_DOMAIN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,7 +64,49 @@ class PendingFileServiceTest {
         // then
         ArgumentCaptor<List<PendingFileEntity>> captor = ArgumentCaptor.forClass(List.class);
         verify(pendingFileJpaRepository).saveAll(captor.capture());
-        assertThat(captor.getValue().get(0).getDomain()).isEqualTo(filename);
+        assertThat(captor.getValue().getFirst().getDomain()).isEqualTo(filename);
+    }
+
+    @DisplayName("이미 추적 중인 fileKey는 저장 대상에서 제외함")
+    @Test
+    void testTrackPendingFiles_givenAlreadyTrackedFileKeys_willExcludeFromSave() {
+        // given
+        String existingFileKey = TEST_POST_CONTENT_FILE_KEY;
+        String newFileKey = TEST_MEMBER_PROFILE_FILE_KEY;
+        List<String> fileKeys = List.of(existingFileKey, newFileKey);
+        given(pendingFileJpaRepository.findFileKeysByFileKeyIn(fileKeys)).willReturn(List.of(existingFileKey));
+
+        // when
+        pendingFileService.trackPendingFiles(fileKeys);
+
+        // then
+        ArgumentCaptor<List<PendingFileEntity>> captor = ArgumentCaptor.forClass(List.class);
+        verify(pendingFileJpaRepository).saveAll(captor.capture());
+        List<PendingFileEntity> saved = captor.getValue();
+        assertThat(saved).hasSize(1);
+        assertThat(saved.getFirst().getFileKey()).isEqualTo(newFileKey);
+    }
+
+    @DisplayName("fileKey 목록이 null이면 리포지토리를 호출하지 않음")
+    @Test
+    void testTrackPendingFiles_givenNull_willNotCallRepository() {
+        // when
+        pendingFileService.trackPendingFiles(null);
+
+        // then
+        verify(pendingFileJpaRepository, never()).findFileKeysByFileKeyIn(any());
+        verify(pendingFileJpaRepository, never()).saveAll(any());
+    }
+
+    @DisplayName("fileKey 목록이 비어있으면 바로 return함")
+    @Test
+    void testTrackPendingFiles_givenEmptyFileKeyList_willDoNothing() {
+        // when
+        pendingFileService.trackPendingFiles(List.of());
+
+        // then
+        verify(pendingFileJpaRepository, never()).findFileKeysByFileKeyIn(any());
+        verify(pendingFileJpaRepository, never()).saveAll(any());
     }
 
     @DisplayName("fileKey 목록이 존재하면 추적 대상에서 해제함")
@@ -71,12 +114,29 @@ class PendingFileServiceTest {
     void testUntrackPendingFiles_givenNonEmptyList_willDeleteByFileKeyIn() {
         // given
         List<String> fileKeys = List.of(TEST_POST_CONTENT_FILE_KEY);
+        given(pendingFileJpaRepository.findFileKeysByFileKeyIn(fileKeys)).willReturn(fileKeys);
 
         // when
         pendingFileService.untrackPendingFiles(fileKeys);
 
         // then
         verify(pendingFileJpaRepository).deleteByFileKeyIn(fileKeys);
+    }
+
+    @DisplayName("추적되지 않은 fileKey는 삭제 대상에서 제외함")
+    @Test
+    void testUntrackPendingFiles_givenNotTrackedFileKeys_willOnlyDeleteExistingOnes() {
+        // given
+        String trackedFileKey = TEST_POST_CONTENT_FILE_KEY;
+        String untrackedFileKey = TEST_MEMBER_PROFILE_FILE_KEY;
+        List<String> fileKeys = List.of(trackedFileKey, untrackedFileKey);
+        given(pendingFileJpaRepository.findFileKeysByFileKeyIn(fileKeys)).willReturn(List.of(trackedFileKey));
+
+        // when
+        pendingFileService.untrackPendingFiles(fileKeys);
+
+        // then
+        verify(pendingFileJpaRepository).deleteByFileKeyIn(List.of(trackedFileKey));
     }
 
     @DisplayName("fileKey 목록이 null이면 리포지토리를 호출하지 않음")
@@ -86,6 +146,7 @@ class PendingFileServiceTest {
         pendingFileService.untrackPendingFiles(null);
 
         // then
+        verify(pendingFileJpaRepository, never()).findFileKeysByFileKeyIn(any());
         verify(pendingFileJpaRepository, never()).deleteByFileKeyIn(any());
     }
 
@@ -96,6 +157,7 @@ class PendingFileServiceTest {
         pendingFileService.untrackPendingFiles(List.of());
 
         // then
+        verify(pendingFileJpaRepository, never()).findFileKeysByFileKeyIn(any());
         verify(pendingFileJpaRepository, never()).deleteByFileKeyIn(any());
     }
 


### PR DESCRIPTION
- Feat: 회원 프로필 덮어쓰기 API - v2 & v3에서 프로필 덮어쓰기 전에 Wasabi에 파일이 정상적으로 등록되어 있는지 여부를 검증하는 로직 추가
- Fix: 회원 프로필 준비 API - v2에서 이미 하나의 이미지라도 Tracked되어 있으면 데이터 무결성 에러가 반환되던 문제 수정
- Refactor: Wasabi에서 이미지 파일을 찾을 수 없는 에러에 대한 응답 코드를 INTERNAL_SERVER_ERROR에서 NOT_FOUND로 변경
- Refactor: Tracked 또는 Untracked되는 이미지 개수를 정확히 산출
- Docs: V5.1.1 Flyway 마이그레이션 파일 추가
- Docs: Claude Code의 application-secrets.yml로의 접근 차단
- Docs: member-domain-details.md 갱신